### PR TITLE
PIPE2D-276: config: increase number of permitted CRs

### DIFF
--- a/config/pfs.py
+++ b/config/pfs.py
@@ -26,7 +26,7 @@ if hasattr(config, 'repair'):
     config.repair.interp.modelPsf.defaultFwhm = 1.75
     config.repair.cosmicray.cond3_fac = 4
     config.repair.cosmicray.cond3_fac2 = 1
-    config.repair.cosmicray.nCrPixelMax = 60000
+    config.repair.cosmicray.nCrPixelMax = 5000000
     config.repair.cosmicray.minSigma = 10.0
     config.repair.cosmicray.min_DN = 500.0
 


### PR DESCRIPTION
Real spectrograph images are going to have many more cosmic rays than
simulated images; the darks in the integration test certainly do.
Restore the nCrPixelMax back to what it was.