### PR TITLE
Passed a visit0 value instead of visit to the PfsConfig constructor.

### DIFF
--- a/python/lsst/obs/pfs/ingest.py
+++ b/python/lsst/obs/pfs/ingest.py
@@ -262,7 +262,7 @@ class PfsIngestTask(IngestTask):
                     "fiberId", "tract", "patch", "ra", "dec", "catId", "objId",
                     "targetType", "fiberMag", "filterNames", "pfiNominal")
         kwargs = {kk: getattr(design, kk) for kk in keywords}
-        kwargs["visit"] = visit
+        kwargs["visit0"] = visit
         kwargs["pfiCenter"] = kwargs["pfiNominal"]
         PfsConfig(**kwargs).write(dirName)
         self.ingest(infile, outfile, mode=args.mode, dryrun=args.dryrun)


### PR DESCRIPTION
Recent changes (DAMD-49) resulted in the PfsConfig making use of the
special 'visit0' identifier. Without this, the ingestPfsImages code
cannot create a PfsConfig based on a PfsDesign file.

The ingestPfsImages code has now been
updated to make use of that identifier.