### PR TITLE
PIPE2D-536: Correct header info for ReduceArc and BootstrapDetectorMap

### DIFF
--- a/python/lsst/obs/pfs/headerFixes.py
+++ b/python/lsst/obs/pfs/headerFixes.py
@@ -53,7 +53,12 @@ class HeaderFixDatabase:
 
         This is the official list of header fixes to apply.
         """
-        self.add(range(17244, 17298), W_XHP2FR=0)  # Fix duplicate no-value (DM-23928)
+        # Fix duplicate no-value (DM-23928)
+        self.add(range(17244, 17298), W_XHP2FR=0)
+
+        # For Subaru exposures taken during Dec 2019, exposures
+        # labelled as Neon were actually Krypton
+        self.add(list(range(423, 442)) + [43, 54, 60], W_AITNEO=False, W_AITKRY=True)
 
 
 if __name__ == "__main__":

--- a/python/lsst/obs/pfs/pfsMapper.py
+++ b/python/lsst/obs/pfs/pfsMapper.py
@@ -216,6 +216,27 @@ class PfsMapper(CameraMapper):
 
         return exp
 
+    def std_raw_md(self, item, dataId):
+        """Fixup raw header metadata problems.
+
+        This should be done by the CameraMapper base class, but it isn't yet (DM-23959).
+
+        Parameters
+        ----------
+        item : `lsst.daf.base.PropertyList`
+            The raw metadata to be fixed
+
+        dataId : `dict`
+            Dataset identifier
+
+        Returns
+        -------
+        item : `lsst.daf.base.PropertyList`
+            The modified raw metadata.
+        """
+        fix_header(item, translator_class=PfsTranslator)
+        return item
+
     def std_fiberTrace(self, item, dataId):
         """Disable standardization for fiberTrace
 

--- a/python/lsst/obs/pfs/pfsMapper.py
+++ b/python/lsst/obs/pfs/pfsMapper.py
@@ -200,8 +200,22 @@ class PfsMapper(CameraMapper):
         does not exist.
 
         See _shiftAmpPixels() for the implementation.
-        """
 
+        Parameters
+        ----------
+        item : image-like object
+            Can be any of lsst.afw.image.Exposure,
+            lsst.afw.image.DecoratedImage, lsst.afw.image.Image
+            or lsst.afw.image.MaskedImage
+            the image-like object whose header information needs to be patched.
+        dataId : `dict`
+            Dataset identifier
+
+        Returns
+        -------
+        item : image-like object
+            the input object with patched header information.
+        """
         exp = super(PfsMapper, self).std_raw(item, dataId)
 
         md = exp.getMetadata()


### PR DESCRIPTION
Added new method std_raw_md() to fix raw_md headers.
Added docstring for that above method
Added docstring for the previously existing and similar std_raw method.