### PR TITLE
PIPE2D-543: Extend visit range when fixing W_XHP2FR header

### DIFF
--- a/python/lsst/obs/pfs/headerFixes.py
+++ b/python/lsst/obs/pfs/headerFixes.py
@@ -54,7 +54,9 @@ class HeaderFixDatabase:
         This is the official list of header fixes to apply.
         """
         # Fix duplicate no-value (DM-23928)
-        self.add(range(17244, 17298), W_XHP2FR=0)
+        # Undefined values occurred in LAM data
+        # between 2019-05-03 and 2019-06-14
+        self.add(range(16804, 20961), W_XHP2FR=0)
 
         # For Subaru exposures taken during Dec 2019, exposures
         # labelled as Neon were actually Krypton


### PR DESCRIPTION
Full range covers dates between 2019-05-03 and 2019-06-14 where
LAM data were taken.