### PR TITLE
tickets/PIPE2D-1088: isr: don't load bias or dark for n arm

### DIFF
--- a/python/lsst/obs/pfs/isrTask.py
+++ b/python/lsst/obs/pfs/isrTask.py
@@ -363,6 +363,41 @@ class PfsIsrTask(ipIsr.IsrTask):
 
         return result
 
+    def getIsrExposure(self, dataRef, datasetType, dateObs=None, immediate=True):
+        """Retrieve a calibration dataset for removing instrument signature.
+
+        This override refuses to load bias and dark for ``arm=n``: we don't
+        use them in ``runH4RG``.
+
+        Parameters
+        ----------
+        dataRef : `daf.persistence.butlerSubset.ButlerDataRef`
+            DataRef of the detector data to find calibration datasets
+            for.
+        datasetType : `str`
+            Type of dataset to retrieve (e.g. 'bias', 'flat', etc).
+        dateObs : `str`, optional
+            Date of the observation.  Used to correct butler failures
+            when using fallback filters.
+        immediate : `Bool`
+            If True, disable butler proxies to enable error handling
+            within this routine.
+
+        Returns
+        -------
+        exposure : `lsst.afw.image.Exposure` or `None`
+            Requested calibration frame, or `None` if not required.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if no matching calibration frame can be found.
+        """
+        arm = dataRef.dataId["arm"]
+        if arm == "n" and datasetType in ("bias", "dark"):
+            return None
+        return super().getIsrExposure(dataRef, datasetType, dateObs=dateObs, immediate=immediate)
+
     def run(self, ccdExposure, **kwargs):
         """Perform instrument signature removal on an exposure.
 


### PR DESCRIPTION
We don't use bias or dark in runH4RG, but we want to run with the same configuration as for the CCD cameras as far as possible; so we sidestep the loading, and we can execute runH4RG with doBias=True doDark=True and it won't be a problem.