### PR TITLE
Add datasetTypes for ExtractionQaTask

### DIFF
--- a/gen3/butler.yaml
+++ b/gen3/butler.yaml
@@ -25,6 +25,8 @@ datastore:
     LsfDict: lsst.daf.butler.formatters.pickle.PickleFormatter
     Lsf: lsst.daf.butler.formatters.pickle.PickleFormatter
     NevenPsf: lsst.daf.butler.formatters.pickle.PickleFormatter
+    MultipagePdfFigure: pfs.drp.qa.formatters.PdfMatplotlibFormatter
+    QaDict: lsst.daf.butler.formatters.pickle.PickleFormatter
   templates:
     instrument+detector+dither: "{run:/}/{datasetType}.{component:?}/{datasetType}_{component:?}_{instrument:?}_{dither:?}_{detector.full_name:?}_{run}"
     instrument+detector+pfs_design_id: "{run:/}/{datasetType}.{component:?}/{datasetType}_{component:?}_{instrument:?}_{detector.full_name:?}_{pfs_design_id:?}_{run}"
@@ -67,3 +69,7 @@ storageClasses:
     pytype: pfs.drp.stella.lsf.Lsf
   NevenPsf:
     pytype: pfs.drp.stella.NevenPsfContinued.NevenPsf
+  MultipagePdfFigure:
+    pytype: pfs.drp.qa.storageClasses.MultipagePdfFigure
+  QaDict:
+    pytype: pfs.drp.qa.storageClasses.QaDict

--- a/policy/PfsMapper.yaml
+++ b/policy/PfsMapper.yaml
@@ -349,6 +349,33 @@ datasets:
     tables:
     - raw
 
+  extQaStats:
+    template: 'extQaStats/%(dateObs)s/v%(visit)06d/extQaStats-%(visit)06d-%(arm)s%(spectrograph)d.pdf'
+    python: object
+    persistable: ignored
+    storage: MatplotlibStorage
+    level: Ccd
+    tables:
+    - raw
+
+  extQaImage:
+    template: 'extQaImage/%(dateObs)s/v%(visit)06d/extQaImage-%(visit)06d-%(arm)s%(spectrograph)d.pdf'
+    python: object
+    persistable: ignored
+    storage: MatplotlibStorage
+    level: Ccd
+    tables:
+    - raw
+
+  extQaImage_pickle:
+    template: 'extQaImage/%(dateObs)s/v%(visit)06d/extQaImage-%(visit)06d-%(arm)s%(spectrograph)d.pickle'
+    python: dict
+    persistable: ignored
+    storage: PickleStorage
+    level: Ccd
+    tables:
+    - raw
+
   pfsArmLsf:
     template: 'pfsArm/%(dateObs)s/v%(visit)06d/pfsArmLsf-%(visit)06d-%(arm)s%(spectrograph)d.pickle'
     python: dict
@@ -469,6 +496,14 @@ datasets:
   bootstrap_config:
     template: config/bootstrap.py
     python: pfs.drp.stella.bootstrap.BootstrapConfig
+    persistable: Config
+    storage: ConfigStorage
+    tables:
+    - raw
+
+  extractionQa_config:
+    template: config/extractionQa.py
+    python: pfs.drp.qa.extractionQa.ExtractionQaConfig
     persistable: Config
     storage: ConfigStorage
     tables:


### PR DESCRIPTION
extQaStats, extQaImage, extQaImage_pickle, and extractionQa_config are added to PfsMapper.yaml

These datasets are output by ExtractionQaTask.

Several entries are also added to butler.yaml for gen3 butler to handle these datasets.