### PR TITLE
PIPE2D-1200: Add basic up-the-ramp processing

### DIFF
--- a/bin.src/checkPfsRawHeaders.py
+++ b/bin.src/checkPfsRawHeaders.py
@@ -7,7 +7,7 @@ from lsst.obs.pfs.checkRawHeader import checkRawHeader
 from astropy import log
 
 
-def main(filenames: Iterable[str], allowFix: bool = False):
+def main(filenames: Iterable[str], allowFix: bool = False, doNIR: bool = False):
     """Main driver to check/fix PFS headers
 
     Parameters
@@ -16,13 +16,15 @@ def main(filenames: Iterable[str], allowFix: bool = False):
         List of files (or globs) for which to check/fix headers.
     allowFix : bool, optional
         Allow headers to be fixed?
+    doNIR : bool, optional
+        Check NIR files?
     """
     numGood = 0
     numBad = 0
     for gg in filenames:
         for fn in glob(gg):
             try:
-                checkRawHeader(fn, allowFix)
+                checkRawHeader(fn, allowFix, doNIR)
                 numGood += 1
             except Exception as exc:
                 log.warning(exc)
@@ -33,6 +35,7 @@ def main(filenames: Iterable[str], allowFix: bool = False):
 if __name__ == "__main__":
     parser = ArgumentParser(description="Check raw PFS files for header compliance")
     parser.add_argument("--fix", default=False, action="store_true", help="Fix bad/missing headers?")
+    parser.add_argument("--nir", default=False, action="store_true", help="Check NIR files?")
     parser.add_argument("filenames", nargs="+", help="Names of files (or glob) to check")
     args = parser.parse_args()
-    main(args.filenames, args.fix)
+    main(args.filenames, args.fix, args.nir)

--- a/python/lsst/obs/pfs/isrTask.py
+++ b/python/lsst/obs/pfs/isrTask.py
@@ -18,9 +18,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from typing import Optional
+
 import os
+import time
+
 import numpy as np
-import numpy.linalg
+import scipy
+import ruamel.yaml as yaml
+
 import lsst.log
 import lsst.geom as geom                # noqa F401; used in eval(darkBBoxes)
 import lsst.pex.config as pexConfig
@@ -82,6 +88,42 @@ class BrokenShutterConfig(pexConfig.Config):
         super().validate()
         if self.window > 1 and self.useAnalytic:
             raise ValueError(f"You may not specify both (window == {self.window}) > 1 and useAnalytic")
+
+
+class H4Config(pexConfig.Config):
+    """Configuration parameters for H4 reductions"""
+
+    quickCDS = pexConfig.Field(dtype=bool, default=False,
+                               doc="Only consider last and first reads instead of the full ramp cube")
+    doCR = pexConfig.Field(dtype=bool, default=True,
+                           doc="Run ramp-based CR rejection. Requires quickCDS=False")
+    crMinReads = pexConfig.Field(dtype=int, default=4,
+                                 doc="Minimum number of dark or shutter-open reads for CR rejection")
+    useIRP = pexConfig.Field(dtype=bool, default=True,
+                             doc="Use Interleaved Reference Pixel planes if available")
+    repairAsicSpikes = pexConfig.Field(dtype=bool, default=True,
+                                       doc="Detect and mask single-pixel, single-read ASIC glitches")
+    repairAsicSpikesSigma = pexConfig.Field(dtype=float, default=3.0,
+                                            doc="Sigma threshold from reads for detecting ASIC glitches")
+    IRPfilter = pexConfig.Field(dtype=int, default=15,  # 15..31, probably.
+                                doc="width of smoothing window for IRP corrections. 0=no smoothing. Odd")
+    doIRPbadPixels = pexConfig.Field(dtype=bool, default=True,
+                                     doc="Interpolate over known bad IRP row pixels"),
+    doIRPcrosstalk = pexConfig.Field(dtype=bool, default=False,
+                                     doc="Correct for data->IRP crosstalk")
+
+    doIPC = pexConfig.Field(dtype=bool, default=True, doc="Correct for IPC?")
+    ipc = pexConfig.DictField(
+        keytype=str,
+        itemtype=str,
+        default=dict(
+            n1="pfsIpc-2023-04-17T13:21:09.707-090750-n1.fits",
+            n2="pfsIpc-2023-11-27T13:21:09.707-102106-n2.fits",
+            n3="pfsIpc-2023-07-15T00:10:01.950-096714-n3.fits",
+            n4="pfsIpc-2024-07-09T00:10:01.950-112241-n4.fits",
+        ),
+        doc="Mapping of detector name to IPC kernel filename",
+    )
 
 
 class PfsAssembleCcdTask(AssembleCcdTask):
@@ -241,9 +283,9 @@ class PfsIsrConnections(PipelineTaskConnections, dimensions=("instrument", "visi
     """Connections for IsrTask"""
 
     ccdExposure = InputConnection(
-        name="raw.exposure",
+        name="raw",
         doc="Input exposure to process.",
-        storageClass="Exposure",
+        storageClass="PfsRaw",
         dimensions=["instrument", "visit", "arm", "spectrograph"],
     )
     camera = PrerequisiteConnection(
@@ -525,6 +567,11 @@ is between value and 100 - value.
 
 The first value should probably always be zero, as we haven't removed any signal at that point,
 but if you have a sufficiently large cosmic ray flux you might want to reconsider.""")
+
+    h4 = pexConfig.ConfigField(
+        dtype=H4Config, doc="H4 related configuration")
+
+    # Probably move to .h4, but check -- CPL
     crosstalk = pexConfig.ConfigurableField(target=PfsCrosstalkTask, doc="Inter-CCD crosstalk correction")
     doIPC = pexConfig.Field(dtype=bool, default=True, doc="Correct for IPC?")
     ipc = pexConfig.DictField(
@@ -726,9 +773,9 @@ class PfsIsrTask(ipIsr.IsrTask):
                     exposureMetadata[runKey] = runValue
                     exposureMetadata[idKey] = idValue
 
-        exposure = inputs["ccdExposure"]
-        if exposure.getFilter().bandLabel == "n" and self.config.doIPC:
-            inputs["ipcCoeffs"] = self.readIPC(exposure.getDetector().getName())
+        raw = inputs["ccdExposure"]  # Inheritance requires "ccdExposure", but it's actually a PfsRaw
+        if raw.isNir() and self.config.doIPC:
+            inputs["ipcCoeffs"] = self.readIPC(raw.detector.getName())
 
         outputs = self.run(**inputs)
         butlerQC.put(outputs, outputRefs)
@@ -781,25 +828,26 @@ class PfsIsrTask(ipIsr.IsrTask):
            result : `lsst.pipe.base.Struct`
               Result struct;  see `lsst.ip.isr.isrTask.run`
         """
-        exposure = ccdExposure                         # argument must be called "ccdExposure"; PIPE2D-1093
-
-        if exposure.getFilter().bandLabel == 'n':  # treat H4RGs specially
-            return self.runH4RG(exposure, **kwargs)
+        pfsRaw = ccdExposure  # argument must still be called "ccdExposure"; PIPE2D-1093
+        if pfsRaw.isNir():  # treat H4RGs specially
+            return self.runH4RG(pfsRaw, **kwargs)
         else:
-            return self.runCCD(exposure, **kwargs)
+            return self.runCCD(pfsRaw.getExposure(), **kwargs)
 
     def runCCD(self, ccdExposure, **kwargs):
         """Perform instrument signature removal on a CCD exposure.
 
-        Parameters:
-           exposure : `afwImage.Exposure`
-             The raw data to be processed
-           kwargs : `dict`
-             Dict of extra parameters, e.g. combined bias
+        Parameters
+        ----------
+        exposure : `lsst.afw.image.Exposure`
+             The exposure to be processed
+        kwargs : `dict`
+            Dict of extra parameters, e.g., bias, dark, etc.
 
-        Return:
-           result : `lsst.pipe.base.Struct`
-              Result struct;  see `lsst.ip.isr.isrTask.run`
+        Return
+        ------
+        result : `lsst.pipe.base.Struct`
+            Result struct;  see `lsst.ip.isr.isrTask.run`
         """
         if ccdExposure.getFilter().bandLabel == 'n':  # treat H4RGs specially
             return self.runH4RG(ccdExposure, **kwargs)
@@ -902,15 +950,16 @@ class PfsIsrTask(ipIsr.IsrTask):
         return results
 
     def runH4RG(
-        self, exposure, dark=None, flat=None, defects=None, detectorNum=None, ipcCoeffs=None, **kwargs
+        self, pfsRaw, dark=None, flat=None, defects=None, detectorNum=None, ipcCoeffs=None, **kwargs
     ):
         """Specialist instrument signature removal for H4RG detectors
 
         Parameters
         ----------
-        exposure : `lsst.afw.image.Exposure`
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
             The raw exposure that is to be run through ISR.  The
-            exposure is modified by this method.
+            exposure is modified by this method. With the PfsRaw we
+            can get access the ramp cubes.
         dark : `lsst.afw.image.Exposure`, optional
             Dark exposure to subtract.
         flat : `lsst.afw.image.Exposure`, optional
@@ -946,28 +995,30 @@ class PfsIsrTask(ipIsr.IsrTask):
             raise RuntimeError("Must supply a flat exposure if config.doFlat=True.")
         if self.config.doDefect and defects is None:
             raise RuntimeError("Must supply defects if config.doDefect=True.")
-        if self.config.doIPC:
+        if self.config.h4.doIPC:
             if defects is None:
                 raise RuntimeError("Must supply defects if config.doIPC=True.")
             if ipcCoeffs is None:
                 raise RuntimeError("Must supply IPC coefficients if config.doIPC=True.")
 
-        nQuarter = exposure.getDetector().getOrientation().getNQuarter()
-        if nQuarter != 0:
-            exposure.maskedImage = afwMath.rotateImageBy90(exposure.maskedImage, nQuarter)
+        # All 3-d ramp-based operations are hidden inside this call. After .makeNirExposure()
+        # we operate on a 2-d image.
+        exposure = self.makeNirExposure(pfsRaw)
 
-        # Think about the ordering here.  E.g. dark subtraction before defects
         assert len(exposure.getDetector()) == 1, "Fix me now we have multiple channels"
 
         channel = exposure.getDetector()[0]
         gain = channel.getGain()
 
-        exposure.image *= gain        # convert to electrons
-        var = exposure.image.clone()  # assumes photon noise -- not true for the persistence
+        exposure.image *= gain  # convert to electrons
+        var = exposure.image.array.copy()  # assumes photon noise -- not true for the persistence
         var += 2*channel.getReadNoise()**2  # 2* comes from CDS
-        exposure.variance = var
+        exposure.variance.array[:] = var
 
-        if self.config.doIPC:
+        # Any nquarter stuff should be removed after PIPE2D-1200
+        nQuarter = exposure.getDetector().getOrientation().getNQuarter()
+
+        if self.config.h4.doIPC:
             self.log.info("Applying IPC correction.")
             self.correctIPC(exposure, defects, ipcCoeffs, -nQuarter)
 
@@ -994,6 +1045,928 @@ class PfsIsrTask(ipIsr.IsrTask):
                                ossThumb=None,
                                )
 
+    def _makeExposure(self, pfsRaw, image):
+        """Re-construct an Exposure from an Image.
+
+        Only intended to be used at the end of H4 ramp processing. Uses the PHDU from
+        the raw ramp to construct a new one, given the processed 2D image.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+            The raw exposure that we ran through ISR.
+        image : `np.ndarray`
+            The output of H4 ISR processing.
+
+        Returns
+        -------
+        exposure : `lsst.afw.image.Exposure`
+            The corrected 2-d image
+        """
+        maskedIm = afwImage.makeMaskedImageFromArrays(image, None, None)
+        exposure = afwImage.makeExposure(maskedIm)
+        exposure.setDetector(pfsRaw.detector)
+        info = exposure.getInfo()
+        info.setVisitInfo(pfsRaw.visitInfo)
+        info.setId(pfsRaw.visitInfo.id)
+        info.setMetadata(pfsRaw.metadata)
+        info.setDetector(pfsRaw.detector)
+        arm = pfsRaw.obsInfo.ext_arm
+        info.setFilter(afwImage.FilterLabel(arm, arm))
+        return exposure
+
+    def makeNirExposure(self, pfsRaw):
+        """Construct a 2D image from the NIR ramp data.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+            Provides access to the ramp that is to be
+            run through ISR.
+
+        Returns
+        -------
+        exposure : `lsst.afw.image.Exposure`
+            The 2-d image from the ramp.
+        """
+
+        if pfsRaw.irpN > 1:
+            raise NotImplementedError('can only deal with IRP1 for now')
+
+        if self.config.h4.quickCDS:
+            self.log.info("creating quick CDS.")
+            nirImage = self.makeCDS(pfsRaw)
+        else:
+            self.log.info("reading full ramp...")
+            deltas = self.makeUTRdeltas(pfsRaw)
+
+            # We do not currently use the indices of the masked pixels,
+            # but do get them.
+            deltas, posIdx, negIdx = self.correctCRs(pfsRaw, deltas)
+
+            # Eventually switch to using the weighted reads up-the-ramp,
+            # but for now simply integrate up the corrected reads.
+            nirImage = np.sum(deltas, axis=0)
+
+        exposure = self._makeExposure(pfsRaw, nirImage)
+
+        return exposure
+
+    def makeRawDataArray(self, pfsRaw, readNum, fromArray=None) -> np.ndarray:
+        """Fetch a single data read."""
+
+        if fromArray is not None:
+            return fromArray[readNum]
+        else:
+            return pfsRaw.getRawDataImage(readNum).array
+
+    def makeRawIrpArray(self, pfsRaw, readNum, forceIrp1=True, fromArray=None) -> np.ndarray:
+        """Construct a full IRP1 reference image"""
+
+        if fromArray is not None:
+            rawIrpArray = fromArray[readNum]
+        else:
+            rawIrpArray = pfsRaw.getRawIrpImage(readNum).array
+        if forceIrp1:
+            im = self.constructFullIrp(pfsRaw, rawIrpArray)
+        else:
+            im = rawIrpArray
+
+        return im
+
+    def makeSimpleStack(
+        self,
+        pfsRaw,
+        reader,
+        r0: int = 0,
+        r1: int = -1,
+        nreads: Optional[int] = None,
+        bbox: Optional["geom.Box2I"] = None,
+        doDeltas: bool = True,
+    ) -> np.ndarray:
+        """Return all the raw frames in a single 3d stack.
+
+        Args
+        ----
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        reader : `callable`
+          A function to read one image.
+        r0 : `int`
+          The 0-indexed read to start from.
+        r1 : `int`
+          The 0-indexed read to end with. Inclusive.
+        nreads : `int`
+          The number of reads to return, evenly spaced between r0 and r1.
+          Note that this uses `np.linspace`, so you want to be alert.
+        bbox : `Box2I`, optional
+          A bounding box to apply to each image.
+        doDeltas : `bool`
+          Whether to return the ramp as per-read incremental changes, or per-read total flux.
+
+        Returns
+        -------
+        stack : 3-d float32 numpy array
+           the ramp, with axis 0 being the reads.
+        """
+
+        r0 = pfsRaw.positiveIndex(r0)
+        r1 = pfsRaw.positiveIndex(r1)
+        if r1 <= r0:
+            raise ValueError(f'r1 ({r1}) must be greater than r0 ({r0}):')
+        if nreads is None:
+            nreads = r1 - r0 + 1
+        reads = np.linspace(r0, r1, nreads, dtype='i2')
+
+        for r_i, read1 in enumerate(reads):
+            readImg = reader(pfsRaw, read1)
+            if bbox is not None:
+                readImg = readImg[bbox]
+            if r_i == 0:
+                h, w = readImg.shape
+                stack = np.empty(shape=(nreads, h, w), dtype='f4')
+            stack[r_i, :, :] = readImg
+
+        if doDeltas:
+            stack = np.diff(stack, axis=0,
+                            prepend=np.zeros_like(stack[0:1]))
+        return stack
+
+    def makeRawDataDeltas(self, pfsRaw,
+                          r0=0, r1=-1, nreads=None, bbox=None) -> np.ndarray:
+        """Return the raw image reads in a single 3d stack.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        r0 : `int`
+          The 0-indexed read to start from.
+        r1 : `int`
+          The 0-indexed read to end with. Inclusive.
+        nreads : `int`
+          The number of reads to return, evenly spaced between r0 and r1.
+          Note that this uses `np.linspace`, so you want to be alert.
+        bbox : `Box2I`, optional
+          A bounding box to apply to each image.
+        """
+        return self.makeSimpleStack(pfsRaw, reader=self.makeRawDataArray,
+                                    r0=r0, r1=r1, nreads=nreads, bbox=bbox)
+
+    def makeRawIrpDeltas(self, pfsRaw,
+                         r0=0, r1=-1, nreads=None, bbox=None) -> np.ndarray:
+        """Return the raw IRP reads in a single 3d stack.
+
+        See .makeRawDataDeltas.
+
+        Note that IRPn reads are expanded to full IRP1.
+        """
+        return self.makeSimpleStack(pfsRaw, reader=self.makeRawIrpArray,
+                                    r0=r0, r1=r1, nreads=nreads, bbox=bbox)
+
+    def makeRawDataCube(self, pfsRaw,
+                        r0=0, r1=-1, nreads=None, bbox=None) -> np.ndarray:
+        """Return the raw data reads in a single 3d stack, but not incremental.
+
+        This is used just for the ASIC glitch correction.
+        """
+        return self.makeSimpleStack(pfsRaw, reader=self.makeRawDataArray,
+                                    r0=r0, r1=r1, nreads=nreads, bbox=bbox,
+                                    doDeltas=False)
+
+    def makeRawIrpNcube(self, pfsRaw,
+                        r0=0, r1=-1, nreads=None, bbox=None) -> np.ndarray:
+        """Return the raw IRP reads in a single 3d stack, but not IRP1, nor incremental.
+
+        This is used just for the ASIC glitch correction.
+        """
+        from functools import partial
+        reader = partial(self.makeRawIrpArray, forceIrp1=False)
+        return self.makeSimpleStack(pfsRaw, reader=reader,
+                                    r0=r0, r1=r1, nreads=nreads, bbox=bbox,
+                                    doDeltas=False)
+
+    def repairWithWindow(self, deltas, badPixels,
+                         corrRad, corrMin, corrMax,
+                         repairMask=None,
+                         otherIgnore=None) -> np.ndarray:
+        """Replace single pixels with a local correction
+
+        Parameters
+        ----------
+        deltas : `np.ndarray`
+           The 3-d cube of the ramp
+        badPixels : `np.ndarray`
+           A 2-d array of the indices of the reads to replace
+        corrRad : `int`
+           The width of the window (along reads) to use for replacement values
+        corrMin : `int`
+           In the deltas cube, the first read we can use for replacements
+        corrMax : `int`
+           In the deltas cube, the last read we can use for replacements
+        repairMask : `np.ndarray`, optional
+           If set, only apply corrections to these pixels.
+        otherIgnore : `np.ndarray`, optional
+           If set, array of read indices we cannot use for replacements.
+
+        Returns
+        -------
+        correctionWindow : `np.ndarray`
+           The windows we use to make replacements. NaNs ignored.
+           For engineering. Drop once we believe or replace this.
+        """
+        # Use neighboring reads, clipped by the ends of the ramp
+        lowIdx0 = badPixels - corrRad
+        lowIdx = np.maximum(lowIdx0, np.zeros_like(badPixels)+corrMin)
+
+        # If our window hits the end of the valid window, move the
+        # start of the window down.
+        highIdx0 = badPixels + corrRad
+        highIdx = np.minimum(highIdx0, np.zeros_like(badPixels)+corrMax-1)
+        highClip = np.where(highIdx != highIdx0)
+        lowIdx[highClip] = highIdx[highClip] - 2*corrRad+1
+
+        # Average the nearby reads, ignoring any we are correcting.
+        correctionWindow = np.zeros(shape=(2*corrRad+1, deltas.shape[1], deltas.shape[2]))
+        for i in range(2*corrRad + 1):
+            idx_i = lowIdx + i
+            corr1 = np.take_along_axis(deltas, idx_i, axis=0)
+            corr1[idx_i == badPixels] = np.nan
+            if otherIgnore is not None:
+                corr1[idx_i == otherIgnore] = np.nan
+            correctionWindow[i, :, :] = corr1
+        corrections = np.nanmean(correctionWindow, axis=0)
+
+        # This is not the cheapest way to handle repairMask, but re-writing to
+        # make that efficient would be error-prone work.
+        if repairMask is not None:
+            badPixels[~repairMask] = 0
+            corrections[~repairMask] = deltas[0][~repairMask]
+        np.put_along_axis(deltas, badPixels, corrections, axis=0)
+        return correctionWindow
+
+    def correctCRs(self, pfsRaw, deltas: np.ndarray):
+        """Correct cosmic ray hits using the array of flux deltas.
+
+        "Correct" means to detect both the maximum and the minimum increments for each
+        pixel, and replace both of those by a local estimate of the rate.
+
+        Since we are already paying the cost of detecting hot pixels, fold correction
+        of ASIC-injected bad pixels in here. Currently only n3, channel 24. In the
+        delta ramps these appear as paired high/low pixels. We do need to calculate a
+        robust sigma, which is expensive enough that we want to skip it if possible.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        deltas : `np.ndarray`
+           Corrected in place.
+
+        Returns
+        -------
+        deltas : `np.array`
+           The corrected ramp
+        posIdx, negIdx : `np.array`
+           The per-pixel indexes into deltas of the corrected reads.
+        """
+
+        if not self.config.h4.doCR:
+            return deltas, None, None
+
+        # Oh, ultra gross. Just realized that for normal exposures the shutter is
+        # always closed for the first read and at least the last two reads, so
+        # we do not want to use those for interpolation.
+        # Worse, Ar and Ne exposures are illuminated for just one read, so *all*
+        # illuminated pixels would be rejected! If we start taking shorter quartz
+        # exposures those will lose significant flux.
+        # Finally, we do not want to use the closed-shutter reads to identify the
+        # minimum pixels: arc lines, etc. always get dinged. This is pretty dangerous
+        # for short exposures.
+        #
+        # Hack that following logic in for now, but need to somehow fix correctly -- CPL.
+        #  - if nread is "short", apply no correction: must use CR splits for Ar/Ne
+        #  - if exptype is not DARK, do not use first or two last reads
+        #
+        corrRad, corrMin, corrMax = self.calcCorrectionWindow(pfsRaw, len(deltas))
+        if corrMax - corrMin < self.config.h4.crMinReads:
+            self.log.warn(f'ramp is too short to correct CRs (need {self.config.h4.crMinReads}, '
+                          f'have {corrMax}-{corrMin}): you must use splits!')
+            return deltas, None, None
+
+        # Identify both min and max reads for each pixel. This
+        # is fairly expensive...
+        posIdx = np.argmax(deltas, axis=0, keepdims=True)
+        negIdx = np.argmin(deltas, axis=0, keepdims=True)
+
+        self.repairWithWindow(deltas, posIdx,
+                              corrRad, corrMin, corrMax,
+                              otherIgnore=negIdx)
+
+        # Need to correct for masking every max read. One way is to mask every
+        # min read. I hate this.
+        if True:
+            self.repairWithWindow(deltas, negIdx,
+                                  corrRad, corrMin, corrMax,
+                                  otherIgnore=posIdx)
+        else:
+            negIdx *= 0
+            self.log.warn('NOT accounting for min pixels in CR step.')
+
+        # we mask/replace two reads for every single pixel. Let the caller decide
+        # what to do about that, but return the indices of both.
+        return deltas, posIdx, negIdx
+
+    def loadBadIRPpixels(self, detectorName: str) -> np.ndarray:
+        """Return the bad IRP row pixel list."""
+
+        filename = 'badRefPixels.yaml'
+        absFilename = os.path.join(getPackageDir("drp_pfs_data"), "h4", filename)
+        if not os.path.exists(absFilename):
+            self.log.warn(f'{absFilename} not found')
+            return np.zeros(dtype=np.int16, shape=())
+
+        with open(absFilename) as f:
+            cfg = yaml.safe_load(f)
+
+        if detectorName not in cfg:
+            self.log.warn(f'{detectorName} not defined in {absFilename}')
+            return np.zeros(dtype=np.int16, shape=())
+
+        return np.array(cfg[detectorName])
+
+    def correctBadIrpPixels(self, pfsRaw, refImg):
+        """Given an IRP1 image, interpolate over known bad IRP row pixels.
+
+        Given the large offsets between the reference pixels and the drifts across the full reads,
+        it only really makes sense to run this on two subtracted IRP reads.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        refImg : `numpy.ndarray`
+           An IRP1 image. Corrected in place.
+        """
+        if not self.config.h4.doIRPbadPixels:
+            return
+        if pfsRaw.irpN != 1:
+            self.log.warn('Do not know how to correct for bad IRP pixels in non-IRP1 images')
+            return
+
+        badPixels = self.loadBadIRPpixels(pfsRaw.detector.getName())
+
+        # We really want to be doing this on IRP diffs, given the huge common per-pixel offsets.
+        # If not, need to somehow flatten out those offsets.
+        #
+        for i in range(32):
+            pixLow = i*128
+            pixHigh = (i+1)*128
+            chan0 = refImg[pixLow:pixHigh, :]
+
+            chanBadPix = badPixels[(badPixels >= pixLow) & (badPixels < pixHigh)] - pixLow
+            if len(chanBadPix) > 0:
+                # Use median of entire column in channel: trying to correct for
+                # fairly local (as seen in column) 1/f
+                chan0[chanBadPix, :] = np.nanmedian(chan0, axis=0)
+
+    def loadBadAsicChannels(self, detectorName: str) -> tuple:
+        # Yes, yes, get this from a config file...
+        badAsicChannels = dict(n3=(24,))
+        return badAsicChannels.get(detectorName, ())
+
+    def getFinalDiffIrp(self, pfsRaw, rawDiffIrp, useFft=True) -> np.ndarray:
+        """Given a simple IRP difference image, return the final IRP image.
+
+        We do a few things here:
+         - replace the detector columns from known bad IRP row pixels with
+           the median of their channel
+         - per-channel, smooth the IRP image rows over {filterWidth} pixels
+
+        For the moment, we assume that the following has been done before
+        we are called:
+          - IRPn images have been filled out into IRP1 images.
+          - Any crosstalk/leakage from the data images has been removed.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        rawDiffIrp : `numpy.ndarray`
+            The raw difference IRP image. Full-size (i.e. IRP1)
+        filterWidth : `int`
+            The width of the smoothing filter to use. Should be odd.
+
+        Returns
+        -------
+        finalIrp : `np.ndarray`
+            The processed IRP image.
+           """
+
+        self.correctBadIrpPixels(pfsRaw, rawDiffIrp)
+
+        skipChannels = self.loadBadAsicChannels(pfsRaw.detector.getName())
+
+        filterWidth = self.config.h4.IRPfilter
+        if filterWidth == 0:
+            return rawDiffIrp
+        if filterWidth % 2 == 0:
+            raise ValueError(f'filterWidth must be odd: {filterWidth}')
+        if skipChannels is None:
+            skipChannels = []
+
+        nchan = pfsRaw.nchan
+        h, w = rawDiffIrp.shape
+        chan_w = h//nchan
+
+        # Construct a cos bell filter to run over each channel.
+        # Pad filter with zeros to same width as padded channel.
+        ww_half = filterWidth//2
+        padWidth = ww_half*2
+        filtCore = scipy.signal.hann(filterWidth)
+        filtCore /= filtCore.sum()
+        filt1 = np.zeros(shape=(chan_w+padWidth, 1), dtype='f4')
+        fc = (chan_w+filterWidth)//2
+        filt1[fc-ww_half:fc+ww_half+1, 0] = filtCore
+        filt = np.tile(filt1, (1, w))
+
+        # scratch space for the padded channel
+        chan1 = np.zeros(shape=(chan_w+padWidth, w), dtype=rawDiffIrp.dtype)
+        out = np.zeros_like(rawDiffIrp)
+        for chan_i in range(nchan):
+            rowLow = chan_i*chan_w
+            rowHigh = (chan_i + 1)*chan_w
+            chan0 = rawDiffIrp[rowLow:rowHigh, :].copy()
+
+            if chan_i in skipChannels:
+                out[rowLow:rowHigh, :] = chan0
+                self.log.debug(f'skipping repairs on channel {chan_i}')
+            else:
+                # Pad channel with median of channel out to half the filter width
+                chan1[ww_half:chan_w+ww_half, :] = chan0
+                chan1[:ww_half, :] = np.nanmedian(chan0[:ww_half, :], axis=0, keepdims=True)
+                chan1[-ww_half:, :] = np.nanmedian(chan0[-ww_half:, :], axis=0, keepdims=True)
+
+                if useFft:
+                    chan_f = scipy.signal.fftconvolve(chan1, filt, mode='same', axes=0)
+                else:
+                    chan_f = scipy.signal.oaconvolve(chan1, filt, mode='same', axes=0)
+                out[rowLow:rowHigh, :] = chan_f[ww_half:chan_w+ww_half, :]
+
+        return out
+
+    def interpolateChannelIrp(self, pfsRaw,
+                              rawChan: np.ndarray,
+                              doFlip: bool) -> np.ndarray:
+        """Given an IRPn channel from a PFSB file, return IRP1-sized channel image.
+
+        Parameters
+        ----------
+        rawChan : array
+           The raw IRP channel, with the columns possibly subsampled by a factor of self.irpN.
+        doFlip : `bool`
+           Whether we need to treat this channel as read out R-to-L. Only meaningful if
+           we are filtering in time.
+
+        Returns
+        -------
+        im : `np.ndarray`
+           the full-sized interpolated reference pixel channel.
+
+        We do not yet know how best to interpolate, so simply repeat the pixels refRatio times.
+        We do not handle the IRP row bad pixel mask, which is a *major* flaw.
+        """
+
+        irpN = pfsRaw.irpN
+        if irpN <= 1:
+            return rawChan
+
+        # Allow the future possibility of using readout order.
+        temporalFilter = False
+
+        irpHeight, irpWidth = rawChan.shape
+        refChan = np.empty(shape=(irpHeight, irpWidth * irpN), dtype=rawChan.dtype)
+
+        if doFlip and temporalFilter:
+            rawChan = rawChan[:, ::-1]
+
+        # For now, simply repeat reference pixels
+        for i in range(0, irpN):
+            refChan[:, i::irpN] = rawChan
+
+        if doFlip and temporalFilter:
+            refChan = refChan[:, ::-1]
+
+        return refChan
+
+    def constructFullIrp(self, pfsRaw, refImg) -> np.ndarray:
+        """Given an IRPn image, return IRP1 image.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        refImg : ndarray
+          A raw reference read from the ASIC.
+
+        Returns
+        -------
+        img : `np.ndarray`
+          full 4096x4096 image.
+
+        Notes
+        -----
+        - The detector was read out in nChannel channels, usually 32, but possibly 16, 4, or 1.
+
+        - By default, the read order from the detector of pairs of channels is --> <--, but
+          it can any other pairing.
+          The ASIC "corrects" that order so that the image always "looks" right: the
+          column-order of the image from the ASIC is spatially, not temporally, correct.
+
+        - the N:1 ratio of science to reference pixels is deduced from the size of the image.
+
+        - self.irpOffset tells us the position of the reference pixel within the N
+          science pixels. It must be >= 1 (there must be at least one
+          science pixel before the reference pixel). The ASIC default is
+          for it to be the last pixel in the group, but we usually try to
+          put the reference pixel in the middle of the block of science pixels.
+        """
+
+        height, width = refImg.shape
+        nchan = pfsRaw.nchan
+
+        # If we are a full frame, no interpolation is necessary.
+        if width == pfsRaw.h4Size:
+            return refImg
+
+        refChanWidth = width // nchan
+
+        refChans = []
+        readOrders = pfsRaw.getH4channelReadOrder()
+        for c_i in range(nchan):
+            rawChan = refImg[:, c_i*refChanWidth:(c_i+1)*refChanWidth]
+            doFlip = readOrders[c_i%2]
+
+            # This is where we would intelligently interpolate.
+            refChan = self.interpolateChannelIrp(pfsRaw, rawChan, doFlip)
+            refChans.append(refChan)
+
+        fullRefImg = np.hstack(refChans)
+
+        return fullRefImg
+
+    def applyIRPcrosstalk(self, pfsRaw, ref, image) -> np.ndarray:
+        """Correct crosstalk from the data pixels to the IRP
+
+        It appears that crosstalk varies "per channel", but we have
+        not looked into what happens with non-32channel ramps.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        ref : `np.ndarray`
+           The IRP image to modify.
+           Corrected in place.
+        image : `np.ndarray`
+           The crosstalk source image.
+
+        Returns
+        -------
+        ref : `np.ndarray`
+           The corrected image. Same as `ref`.
+
+        """
+        if not self.config.h4.doIRPcrosstalk:
+            return ref
+        raise NotImplementedError('not loading crosstalk yet')
+
+        crosstalkFactors = self.loadIRPcrosstalk(pfsRaw)
+
+        nchan = pfsRaw.nchan
+        chanStep = 32//nchan
+        chanWidth = pfsRaw.h4Size / nchan
+
+        for c in range(nchan):
+            xslice = slice(c*chanWidth, (c+1)*chanWidth)
+            ref[xslice, :] -= image[xslice, :] * crosstalkFactors[c*chanStep]
+
+        return ref
+
+    def borderCorrect(self, pfsRaw, image, colWindow=4,
+                      doRows=True, doCols=True):
+        """This is the "standard" Teledyne 'refPixel4' border reference pixel scheme.
+
+        Step 1:
+           For each channel, average all 8 top&bottom rows to one number.
+           Subtract that from the channel.
+
+        Step 2:
+            Take a 9-row running average of the left&right columns.
+            Subtract that from each row.
+
+        The output is not lovely but is functional. We are mainly here just to duplicate their
+        standard logic. So please do *not* modify/improve this particular routine: we want to have
+        it for any support discussions. Ok, maybe this should have been named 'borderCorrectRefPixel4'.
+        """
+        refPix = 4
+
+        imHeight, imWidth = image.shape
+        if imHeight != pfsRaw.h4Size or imWidth != pfsRaw.h4Size:
+            raise RuntimeError('not ready to deal with non-full images')
+
+        if doCols:
+            top = image[imHeight-refPix:, :]
+            bottom = image[:refPix, :]
+
+            chanWidth = imWidth // pfsRaw.nchan
+            for c_i in range(pfsRaw.nchan):
+                xlow = c_i * chanWidth
+                xhigh = xlow + chanWidth
+                # Leave ref columns unmolested.
+                if c_i == 0:
+                    xlow = refPix
+                elif c_i == pfsRaw.nchan-1:
+                    xhigh = imWidth-refPix
+                ichan = image[:, xlow:xhigh]
+
+                chanOffset = (top[:, xlow:xhigh].mean()
+                              + bottom[:, xlow:xhigh].mean()) / 2
+                ichan -= chanOffset
+
+        if doRows:
+            sideRefImage = np.ndarray((imHeight, refPix*2), dtype=image.dtype)
+            sideRefImage[:, :refPix] = image[:, :refPix]
+            sideRefImage[:, refPix:] = image[:, imWidth-refPix:]
+            sideCorr = np.zeros((imHeight, 1))
+
+            # Not quite right at the ends -- should not be including the reference rows.
+            for row_i in range(colWindow, imHeight-colWindow+1):
+                sideCorr[row_i] = sideRefImage[row_i-colWindow:row_i+colWindow, :].mean()
+                image[row_i, :] -= sideCorr[row_i]
+
+        return image
+
+    def makeCDS(self, pfsRaw, r0=0, r1=-1):
+        """Get a single reference-corrected CDS from a ramp. Does not read full ramp.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        r0 : `int`
+            The read to start from. 0-indexed.
+        r1 : `int`
+            The read to end at. 0-indexed.
+
+        Returns
+        -------
+        image : `afw.image.ImageF`
+            reference-corrected image.
+        """
+
+        r0 = pfsRaw.positiveIndex(r0)
+        r1 = pfsRaw.positiveIndex(r1)
+        if r1-r0 < 1:
+            raise ValueError(f'r1 ({r1}) must be greater than r0 ({r0}) + 1:')
+
+        image0 = self.makeRawDataArray(pfsRaw, r0)
+        image1 = self.makeRawDataArray(pfsRaw, r1)
+
+        if self.config.h4.useIRP and pfsRaw.irpN > 0:
+            ref0 = self.makeRawIrpArray(pfsRaw, r0)
+            self.applyIRPcrosstalk(pfsRaw, ref0, image0)
+            ref1 = self.makeRawIrpArray(pfsRaw, r1)
+            self.applyIRPcrosstalk(pfsRaw, ref1, image1)
+
+            dref = ref1 - ref0
+            dref = self.getFinalDiffIrp(pfsRaw, dref)
+
+            image1 -= image0
+            image1 -= dref
+        else:
+            image0 = self.borderCorrect(pfsRaw, image0)
+            image1 = self.borderCorrect(pfsRaw, image1)
+            image1 -= image0
+
+        return image1
+
+    def calcCorrectionWindow(self, pfsRaw, nread, corrRad=2):
+        """Figure out the bounds of any interpolation/correction window for this ramp
+
+        If illuminated, we cannot use the reads when the shutter is closed;
+        currently (2025-01) the first and the last two.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        nread : `int`
+          The number of actual reads we have kept.
+        corrRad : `int`
+          How many reads on either side we want to use
+
+        Returns
+        -------
+        corrRad : `int`
+           The radius of the window we keep.
+        corrMin, corrMax : `int`
+           The first and last reads we can use
+        """
+
+        exptype = pfsRaw.visitInfo.observationType
+
+        if exptype == 'dark' or nread < pfsRaw.getNumReads():
+            corrMin = 0
+            corrMax = nread-1
+        else:
+            # TODO: figure the shutter-closed reads out from the header. Need to add cards for that.
+            # This is correct for 2024-ish.
+            corrMin = 1
+            corrMax = nread-3
+
+        return corrRad, corrMin, corrMax
+
+    def repairAsicSpikes(self, pfsRaw, cube: np.ndarray, channel: int, sigClip=None, doTest=False):
+        """Replace bad pixels from bad ASIC channels
+
+        The bad pixels are positive going spikes from the ASIC, which can hit
+        both data and IRP pixels. We correct the pixels early, on the separate
+        data and IRP cubes, before even being converted to IRP1 or incremental UTR.
+
+        We expect to only run this for a few (1?) channel.
+
+        Need to iterate until no more spikes are found.....
+        Need to handle spikes at the ends of the ramp.
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        cube : `np.ndarray`
+           The 3-d cube of the ramp. Corrected in place.
+        channel : `int`
+           The index of the (32-channel read) channel we are correcting
+        """
+
+        if not self.config.h4.repairAsicSpikes:
+            return
+
+        if pfsRaw.nchan != 32:
+            self.log.warn(f'nchan ({pfsRaw.nchan}) != 32, so not (yet) correcting ASIC glitches')
+            return
+
+        if sigClip is None:
+            sigClip = self.config.h4.repairAsicSpikesSigma
+        badChan = cube[:, channel*128:(channel+1)*128, :]
+
+        diffChan = np.diff(badChan, axis=0, prepend=np.zeros_like(badChan[0:1]))
+        p25, meds, p75 = np.percentile(diffChan, [25, 50, 75], axis=0)
+        iqrSig = 0.741*(p75 - p25)
+
+        # the reads we are correcting have a single hot pixel, just like CRs. But the flux
+        # levels return on the following read, unlike CRs. So, in delta stacks look for
+        # positive spikes just before a matching negative spike. Or in cumulative stacks,
+        # look for a positive spike between two "normal" reads
+        brightMask = np.abs(diffChan) > (meds + sigClip*iqrSig)
+        bright_w = np.where(brightMask)
+
+        # Todo: Handle spikes at the ends of the ramp separately -- CPL
+        atEnd = (bright_w[0] >= len(diffChan)-1 | (bright_w[0] == 0))
+        bright_w1 = bright_w[0][~atEnd], bright_w[1][~atEnd], bright_w[2][~atEnd]
+        next_w1 = (bright_w1[0]+1), bright_w1[1], bright_w1[2]
+
+        peaks1 = diffChan[bright_w1]
+        next1 = diffChan[next_w1]
+        diffs = peaks1 + next1
+
+        meds1 = meds[bright_w1[1:]]
+        iqrSig1 = iqrSig[bright_w1[1:]]
+
+        fix_i = np.abs(diffs) < (meds1 + sigClip*iqrSig1)
+        fix_w = tuple([w1[fix_i] for w1 in bright_w1])
+        if True:  # Use the average of the two neighboring reads
+            fix_wm1 = (fix_w[0]-1, fix_w[1], fix_w[2])
+            fix_wp1 = (fix_w[0]+1, fix_w[1], fix_w[2])
+            repairVals = (badChan[fix_wm1] + badChan[fix_wp1]) / 2
+        else:     # Use the median of the entire ramp
+            repairVals = meds1[fix_w[1:]]
+        badChan[fix_w] = repairVals
+
+        # Return for testing
+        if doTest:
+            return fix_w, badChan, diffChan, bright_w1, iqrSig, meds, repairVals
+        else:
+            return fix_w
+
+    def makeUTRdeltas(self, pfsRaw, r0=0, r1=-1, nreads=None, bbox=None,
+                      showTimes=False) -> np.ndarray:
+        """Return all the fully IRP-corrected frames in a single 3d stack.
+
+        Given two raw data images d0 and d1, and two raw IRP images i0 and i1, the net CDS image
+        can be either (d1 - i1) - (d0 - i0), or (d1 - d0) - (i1 - i0). The IRP row has various
+        artifacts which make using the latter "nicer", or at least easier to make sense of. So that
+        is the way we do it.
+        In particular there are:
+          - bad IRP row pixels
+          - fixed pixel-to-pixel offsets
+          - bad ASIC channels
+
+        Note that there is also up to ~1% printthrough from data->IRP, and presumably from IRP->data
+
+        Parameters
+        ----------
+        pfsRaw : `lsst.obs.pfs.PfsRaw`
+          Access to the raw ramp
+        r0 : `int`
+          The 0-indexed read to start from.
+        r1 : `int`
+          The 0-indexed read to end with. Inclusive.
+        nreads : `int`, optional.
+          The number of reads to return, spaced evenly between r0 and r1.
+        filterIrp : `bool`
+            Whether to apply known corrections to the IRP images.
+        bbox : `lsst.geom.Box2I`
+            The region of the image to return. If None, return the whole image.
+
+        Returns
+        -------
+        deltas : 3-d float32 numpy array
+           the UTR stack, with axis 0 being the reads up the ramp. We return
+           the flux increments between reads, not the actual fluxes.
+        """
+
+        r0 = pfsRaw.positiveIndex(r0)
+        r1 = pfsRaw.positiveIndex(r1)
+        if r1-r0 < 1:
+            raise ValueError(f'r1 ({r1}) must be greater than r0 ({r0}) + 1:')
+        if nreads is None:
+            nreads = r1 - r0 + 1
+        reads = np.linspace(r0, r1, nreads, dtype='i2')
+
+        # n3/18321 channel 24 is covered with pixels which have spikes from the ASIC.
+        # We need to repair both the data and IRP pixels separately, and furthermore
+        # want to repair the non-interpolated IRP images. So read both in first and
+        # correct them before building the proper deltas. Since I/O is significant,
+        # we keep the raw data and IRP cubes, then re-read from those instead of
+        # from disk.
+        #
+        badChans = self.loadBadAsicChannels(pfsRaw.detector.getName())
+        if badChans is not None:
+            rawData = self.makeRawDataCube(pfsRaw=pfsRaw, r0=r0, r1=r1, nreads=nreads)
+            rawIrps = self.makeRawIrpNcube(pfsRaw=pfsRaw, r0=r0, r1=r1, nreads=nreads)
+
+            for badChan in badChans:
+                fixedData_w = self.repairAsicSpikes(pfsRaw, rawData, badChan)
+                fixedIrp_w = self.repairAsicSpikes(pfsRaw, rawIrps, badChan)
+                self.log.info(f'repaired {len(fixedData_w[0])} data and {len(fixedIrp_w[0])} IRP '
+                              f'ASIC pixels in channel {badChan}')
+        else:
+            rawData = rawIrps = None
+
+        # Grab the components of read 0, which we will subtract from all the others.
+        if rawData is not None:
+            data0 = self.makeRawDataArray(pfsRaw, 0, fromArray=rawData)
+            irp0 = self.makeRawIrpArray(pfsRaw, 0, fromArray=rawIrps)
+        else:
+            data0 = self.makeRawDataArray(pfsRaw, r0, fromArray=rawData)
+            irp0 = self.makeRawIrpArray(pfsRaw, r0, fromArray=rawIrps)
+        self.applyIRPcrosstalk(pfsRaw, irp0, data0)
+
+        # We are not squirreling away the bbox, but really should for the final Exposure
+        if bbox is None:
+            stackShape = (nreads-1, *data0.shape)
+        else:
+            stackShape = (nreads-1, bbox.getHeight(), bbox.getWidth())
+        stack = np.empty(shape=stackShape, dtype='f4')
+        for r_idx, r_i in enumerate(reads):
+            if r_idx == 0:
+                continue
+            t0 = time.time()
+            if rawData is not None:
+                data1 = self.makeRawDataArray(pfsRaw, r_idx, fromArray=rawData)
+                irp1 = self.makeRawIrpArray(pfsRaw, r_idx, fromArray=rawIrps)
+            else:
+                data1 = self.makeRawDataArray(pfsRaw, r_i, fromArray=rawData)
+                irp1 = self.makeRawIrpArray(pfsRaw, r_i, fromArray=rawIrps)
+            t1 = time.time()
+            self.applyIRPcrosstalk(pfsRaw, irp1, data1)
+            dirp = irp1 - irp0
+            ddata = data1 - data0
+            ddata -= self.getFinalDiffIrp(pfsRaw, dirp)
+            if bbox is None:
+                stack[r_idx-1, :, :] = ddata
+            else:
+                stack[r_idx-1, :, :] = ddata[bbox.getBeginY():bbox.getEndY(),
+                                             bbox.getBeginX():bbox.getEndX()]
+            t2 = time.time()
+            if showTimes:
+                print(f'cds {r_i} io1={t1-t0:0.3f} proc={t2-t1:0.3f}')
+
+        # Warning: prepend=0 causes promotion to float64
+        # This should arguably be constructed on-the-fly, read by read.
+        return np.diff(stack, axis=0, prepend=np.zeros_like(stack[0:1]))
+
     def readIPC(self, detectorName: str) -> dict[int, dict[int, float]]:
         """Read IPC coefficients from file
 
@@ -1011,7 +1984,7 @@ class PfsIsrTask(ipIsr.IsrTask):
             IPC coefficients. ``ipcCoeffs[dx][dy]`` is the fraction of flux at
             (dx, dy).
         """
-        filename = self.config.ipc[detectorName]
+        filename = self.config.h4.ipc[detectorName]
         if not os.path.isabs(filename):
             absFilename = os.path.join(getPackageDir("drp_pfs_data"), "ipc", filename)
             if os.path.exists(absFilename):


### PR DESCRIPTION
We want the H4 parts of the isrTask to have access to the full ramp cube, but also want the isrTask to remain compatible with lsst.ip.isr, especially for b/r/m. Our fiddle is to have the butler return a PfsRaw object, which provides normal 2d images for the visible, and access to the ramp reads for the NIR.

Have isrTask accept PfsRaw instead of Exposure.
Hoist H4 processing configs into .h4 section.
Rotate images immediately when reading.