### PR TITLE
Add the dataset type of a drp_1dpipe product

### DIFF
--- a/gen3/butler.yaml
+++ b/gen3/butler.yaml
@@ -23,6 +23,7 @@ datastore:
     PfsObjectSpectra: lsst.obs.pfs.formatters.PfsObjectSpectraFormatter  # deprecated
     PfsCalibrated: lsst.obs.pfs.formatters.PfsCalibratedFormatter
     PfsCoadd: lsst.obs.pfs.formatters.PfsCoaddFormatter
+    PfsCoZCandidates: lsst.obs.pfs.formatters.PfsCoZCandidatesFormatter
     SkyModel: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
     FocalPlaneFunction: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
     ArcLineSet: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
@@ -109,6 +110,15 @@ storageClasses:
       - obj_id  # Object identifier
     derivedComponents:
       single: PfsObject  # Single spectrum; requires objId/obj_id
+  PfsCoZCandidates:
+    pytype: pfs.datamodel.pfsCoZCandidates.PfsCoZCandidates
+    parameters:
+      - objId  # Object identifier
+      - obj_id  # Object identifier
+    derivedComponents:
+      single: PfsZCandidates  # Single spectrum; requires objId/obj_id
+  PfsZCandidates:
+    pytype: pfs.datamodel.pfsZCandidates.PfsZCandidates
   SkyModel:
     pytype: pfs.drp.stella.sky2d.SkyModel
   FocalPlaneFunction:

--- a/python/lsst/obs/pfs/formatters.py
+++ b/python/lsst/obs/pfs/formatters.py
@@ -238,3 +238,8 @@ class PfsCalibratedFormatter(PfsTargetSpectraFormatter):
 
 class PfsCoaddFormatter(PfsTargetSpectraFormatter):
     PfsTargetSpectraClass = "pfs.datamodel.drp.PfsCoadd"
+
+
+# "PfsCoZCandidates" are not spectra, but the same formatter can be used.
+class PfsCoZCandidatesFormatter(PfsTargetSpectraFormatter):
+    PfsTargetSpectraClass = "pfs.datamodel.PfsCoZCandidates"

--- a/python/lsst/obs/pfs/formatters.py
+++ b/python/lsst/obs/pfs/formatters.py
@@ -194,12 +194,9 @@ class PfsTargetSpectraFormatter(FitsGenericFormatter):
 
     def read_from_local_file(self, path: str, component: str | None = None, expected_size: int = -1) -> Any:
         # Docstring inherited.
-        if self.PfsTargetSpectraClass in ("PfsCalibratedSpectra", "PfsObjectSpectra"):
-            # These are deprecated, but we still need to support them
-            module = import_module("pfs.drp.stella.datamodel.pfsTargetSpectra", )
-        else:
-            module = import_module("pfs.datamodel.drp", )
-        cls = getattr(module, self.PfsTargetSpectraClass)
+        module_name, cls_name = self.PfsTargetSpectraClass.rsplit(".", 1)
+        module = import_module(module_name)
+        cls = getattr(module, cls_name)
 
         path = self.file_descriptor.location.path
         spectra = cls.readFits(path)
@@ -227,17 +224,17 @@ class PfsTargetSpectraFormatter(FitsGenericFormatter):
 
 # Deprecated in favor of PfsCalibratedFormatter
 class PfsCalibratedSpectraFormatter(PfsTargetSpectraFormatter):
-    PfsTargetSpectraClass = "PfsCalibratedSpectra"
+    PfsTargetSpectraClass = "pfs.drp.stella.datamodel.pfsTargetSpectra.PfsCalibratedSpectra"
 
 
 # Deprecated in favor of PfsCoaddFormatter
 class PfsObjectSpectraFormatter(PfsTargetSpectraFormatter):
-    PfsTargetSpectraClass = "PfsObjectSpectra"
+    PfsTargetSpectraClass = "pfs.drp.stella.datamodel.pfsTargetSpectra.PfsObjectSpectra"
 
 
 class PfsCalibratedFormatter(PfsTargetSpectraFormatter):
-    PfsTargetSpectraClass = "PfsCalibrated"
+    PfsTargetSpectraClass = "pfs.datamodel.drp.PfsCalibrated"
 
 
 class PfsCoaddFormatter(PfsTargetSpectraFormatter):
-    PfsTargetSpectraClass = "PfsCoadd"
+    PfsTargetSpectraClass = "pfs.datamodel.drp.PfsCoadd"


### PR DESCRIPTION
For a drp_1dpipe product to be gettable with butler, its datasetType has to be put into butler.yaml.