### PR TITLE
PIPE2D-1856: install badRefPixels and defects as certified calibrations

### DIFF
--- a/bin.src/makePfsCalibs.py
+++ b/bin.src/makePfsCalibs.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+"""Install PFS calibration products into a Gen3 butler.
+
+The ``badRefPixels`` and ``defects`` calibrations live as data files in the
+``drp_pfs_data`` package. This script reads them, ``butler.put``s them into a
+RUN collection, and ``registry.certify``s them into a CALIBRATION collection
+with a validity timespan, so that the pipeline selects the appropriate version
+by observation date (rather than by EUPS setup).
+
+Collections follow the DMTN-222 convention
+``{root}/{ticket}/{tag}/{product}Gen.{iteration}``, where ``{iteration}`` is a
+``YYYYMMDDv`` date string (creation date plus a trailing letter, incremented if
+a generation is retried). The root defaults to ``PFS/calib`` but may be
+overridden (e.g. ``u/<user>/<ticket>``) for testing.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+from argparse import ArgumentParser
+from glob import glob
+
+import astropy.time
+import ruamel.yaml as yaml
+
+from lsst.daf.butler import Butler, CollectionType, Timespan
+from lsst.ip.isr import Defects
+from lsst.utils import getPackageDir
+
+from lsst.obs.pfs.nirBadRefPixels import NirBadRefPixels
+
+NIR_CAMERAS = ("n1", "n2", "n3", "n4")
+
+
+def isoTai(value: str | None) -> astropy.time.Time | None:
+    """Parse an ISO-8601 TAI string into a `~astropy.time.Time` (or `None`)."""
+    if value is None:
+        return None
+    return astropy.time.Time(value, format="isot", scale="tai")
+
+
+def dateFromFilename(path: str) -> astropy.time.Time:
+    """Parse the validity-start date encoded in a dated calibration filename.
+
+    The stem is an ISO-8601 basic-format datetime, e.g. ``20240815T000000``.
+    Interpreted as UTC, matching the historical curated-calibration behaviour.
+    """
+    stem = os.path.splitext(os.path.basename(path))[0]
+    when = datetime.datetime.fromisoformat(stem)
+    return astropy.time.Time(when, format="datetime", scale="utc")
+
+
+def collectionName(root: str, ticket: str, tag: str, product: str, iteration: str) -> str:
+    """Compose the DMTN-222 CALIBRATION collection name for a product."""
+    return f"{root}/{ticket}/{tag}/{product}Gen.{iteration}"
+
+
+def certifyGroup(butler, calibCollection, run, datasetTypeName, entries):
+    """Put and certify a group of calibrations.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        Writeable butler.
+    calibCollection : `str`
+        CALIBRATION collection to certify into.
+    run : `str`
+        RUN collection to put the datasets into.
+    datasetTypeName : `str`
+        Dataset type name.
+    entries : iterable of (calib, dataId, `~lsst.daf.butler.Timespan`)
+        The calibration objects, their data IDs, and validity timespans.
+    """
+    butler.registry.registerRun(run)
+    with butler.transaction():
+        for calib, dataId, timespan in entries:
+            ref = butler.put(calib, datasetTypeName, dataId, run=run)
+            butler.registry.certify(calibCollection, [ref], timespan)
+
+
+def installBadRefPixels(butler, drpData, calibCollection, instrument, begin, end):
+    """Install the per-detector bad IRP reference-pixel calibrations.
+
+    The multi-camera ``h4/badRefPixels.yaml`` source is split into one
+    per-detector calibration.
+    """
+    path = os.path.join(drpData, "h4", "badRefPixels.yaml")
+    with open(path) as fd:
+        config = yaml.YAML(typ="safe", pure=True).load(fd)
+
+    run = f"{calibCollection}/put"
+    entries = []
+    for cam in NIR_CAMERAS:
+        if cam not in config:
+            print(f"badRefPixels: {cam} not defined in {path}; skipping")
+            continue
+        calib = NirBadRefPixels.fromList(config[cam], cam)
+        dataId = dict(instrument=instrument, arm="n", spectrograph=int(cam[1]))
+        entries.append((calib, dataId, Timespan(begin, end)))
+    certifyGroup(butler, calibCollection, run, "badRefPixels", entries)
+    print(f"badRefPixels: certified {len(entries)} detector(s) into {calibCollection}")
+
+
+def detectorIds(butler, instrument):
+    """Return a mapping of detector full_name -> detector id."""
+    records = butler.registry.queryDimensionRecords("detector", instrument=instrument)
+    return {record.full_name: record.id for record in records}
+
+
+def installDefects(butler, drpData, calibCollection, instrument):
+    """Install the per-detector defects, certifying the existing dated chain.
+
+    Each detector directory holds one or more ISO-dated ``.ecsv`` files. The
+    versions are certified with consecutive validity timespans: version ``i``
+    is valid from its own date until the next version's date, and the final
+    version is valid open-ended.
+    """
+    nameToId = detectorIds(butler, instrument)
+    defectsDir = os.path.join(drpData, "curated", "pfs", "defects")
+
+    numCertified = 0
+    for detectorName in sorted(nameToId):
+        detectorDir = os.path.join(defectsDir, detectorName)
+        paths = sorted(glob(os.path.join(detectorDir, "*.ecsv")))
+        if not paths:
+            continue
+        times = [dateFromFilename(path) for path in paths]
+        ends = times[1:] + [None]
+
+        arm = detectorName[0]
+        spectrograph = int(detectorName[1])
+        detector = nameToId[detectorName]
+
+        for path, begin, end in zip(paths, times, ends):
+            calib = Defects.readText(path)
+            dataId = dict(
+                instrument=instrument, detector=detector, arm=arm, spectrograph=spectrograph
+            )
+            # Each version shares a dataId, so it needs its own RUN.
+            run = f"{calibCollection}/{os.path.splitext(os.path.basename(path))[0]}"
+            certifyGroup(
+                butler, calibCollection, run, "defects", [(calib, dataId, Timespan(begin, end))]
+            )
+            numCertified += 1
+    print(f"defects: certified {numCertified} version(s) into {calibCollection}")
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("repo", help="Path to the butler repository")
+    parser.add_argument("--instrument", default="PFS", help="Instrument name (default: PFS)")
+    parser.add_argument(
+        "--products",
+        nargs="+",
+        default=["badRefPixels", "defects"],
+        choices=["badRefPixels", "defects"],
+        help="Products to install (default: all)",
+    )
+    parser.add_argument("--root", default="PFS/calib", help="Collection root (default: PFS/calib)")
+    parser.add_argument("--ticket", required=True, help="Ticket name, e.g. PIPE2D-1856")
+    parser.add_argument("--tag", required=True, help="Tag/label for this calibration set")
+    parser.add_argument(
+        "--iteration",
+        default=None,
+        help="DMTN-222 rerun iteration (YYYYMMDDv); default: today + 'a'",
+    )
+    parser.add_argument(
+        "--begin-date",
+        default=None,
+        help="Validity start (ISO-8601 TAI) for badRefPixels; default: unbounded",
+    )
+    parser.add_argument(
+        "--end-date",
+        default=None,
+        help="Validity end (ISO-8601 TAI) for badRefPixels; default: unbounded",
+    )
+    args = parser.parse_args()
+
+    iteration = args.iteration
+    if iteration is None:
+        iteration = datetime.date.today().strftime("%Y%m%d") + "a"
+
+    begin = isoTai(args.begin_date)
+    end = isoTai(args.end_date)
+
+    drpData = getPackageDir("drp_pfs_data")
+    butler = Butler(args.repo, writeable=True)
+
+    for product in args.products:
+        calibCollection = collectionName(args.root, args.ticket, args.tag, product, iteration)
+        butler.registry.registerCollection(calibCollection, CollectionType.CALIBRATION)
+        if product == "badRefPixels":
+            installBadRefPixels(butler, drpData, calibCollection, args.instrument, begin, end)
+        elif product == "defects":
+            installDefects(butler, drpData, calibCollection, args.instrument)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin.src/makePfsTestRepo.py
+++ b/bin.src/makePfsTestRepo.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""Create a Gen3 butler repository for PFS, ready for use.
+
+The repository is created with the PFS dimension universe and storage classes,
+and the instrument (together with its calibration dataset types, e.g.
+``nirLinearity``, ``badRefPixels`` and ``defects``) is registered. The result
+can be used directly with ``makePfsCalibs.py`` to install calibration products.
+"""
+
+from __future__ import annotations
+
+import os
+from argparse import ArgumentParser
+
+from lsst.daf.butler import Butler, DimensionConfig
+from lsst.utils import getPackageDir
+
+from lsst.obs.pfs.PrimeFocusSpectrograph import (
+    PfsDevelopment,
+    PfsSimulator,
+    PrimeFocusSpectrograph,
+)
+
+INSTRUMENTS = {
+    "PFS": PrimeFocusSpectrograph,
+    "PFS-F": PfsSimulator,
+    "PFS-L": PfsDevelopment,
+}
+
+
+def makePfsTestRepo(repo: str, instrument: str = "PFS") -> Butler:
+    """Create and populate a PFS butler repository.
+
+    Parameters
+    ----------
+    repo : `str`
+        Path at which to create the repository.
+    instrument : `str`, optional
+        Instrument to register (``PFS``, ``PFS-F`` for the simulator, or
+        ``PFS-L`` for LAM development data).
+
+    Returns
+    -------
+    butler : `lsst.daf.butler.Butler`
+        A writeable butler for the newly created repository.
+    """
+    obsPfsDir = getPackageDir("obs_pfs")
+    dimensionConfig = DimensionConfig(os.path.join(obsPfsDir, "gen3", "dimensions.yaml"))
+    Butler.makeRepo(
+        repo,
+        config=os.path.join(obsPfsDir, "gen3", "butler.yaml"),
+        dimensionConfig=dimensionConfig,
+    )
+    butler = Butler(repo, writeable=True)
+    INSTRUMENTS[instrument]().register(butler.registry)
+    return butler
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("repo", help="Path to the butler repository to create")
+    parser.add_argument(
+        "--instrument",
+        default="PFS",
+        choices=sorted(INSTRUMENTS),
+        help="Instrument to register (default: PFS)",
+    )
+    args = parser.parse_args()
+    makePfsTestRepo(args.repo, args.instrument)
+    print(f"Created {args.instrument} butler repo at {args.repo}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gen3/butler.yaml
+++ b/gen3/butler.yaml
@@ -35,6 +35,7 @@ datastore:
     ImageCube: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
     ObjectGroupMap: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
     NirLinearity: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
+    NirBadRefPixels: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
   templates:
     default: "{run:/}/{datasetType}.{component:?}/{visit.day_obs:?}/{visit:?}/{datasetType}_{component:?}_{instrument:?}_{visit:?}_{arm:?}{spectrograph:?}_{detector:?}_{run}"
     instrument+detector: "{run:/}/{datasetType}.{component:?}/{datasetType}_{component:?}_{instrument:?}_{detector:?}_{run}"  # used for defects
@@ -159,3 +160,5 @@ storageClasses:
     pytype: pfs.datamodel.objectGroupMap.ObjectGroupMap
   NirLinearity:
     pytype: lsst.obs.pfs.nirLinearity.NirLinearity
+  NirBadRefPixels:
+    pytype: lsst.obs.pfs.nirBadRefPixels.NirBadRefPixels

--- a/python/lsst/obs/pfs/PrimeFocusSpectrograph.py
+++ b/python/lsst/obs/pfs/PrimeFocusSpectrograph.py
@@ -149,6 +149,20 @@ class PrimeFocusSpectrograph(Instrument):
             "ImageCube",
             True,
         )
+        self.registerDatasetType(
+            registry,
+            "badRefPixels",
+            ["instrument", "arm", "spectrograph"],
+            "NirBadRefPixels",
+            True,
+        )
+        self.registerDatasetType(
+            registry,
+            "defects",
+            ["instrument", "detector", "arm", "spectrograph"],
+            "Defects",
+            True,
+        )
 
     def registerDatasetType(
         self,

--- a/python/lsst/obs/pfs/isrTask.py
+++ b/python/lsst/obs/pfs/isrTask.py
@@ -28,7 +28,6 @@ from functools import partial
 
 import numpy as np
 import scipy
-import ruamel.yaml as yaml
 
 import lsst.log
 import lsst.geom as geom                # noqa F401; used in eval(darkBBoxes)
@@ -377,6 +376,14 @@ class PfsIsrConnections(PipelineTaskConnections, dimensions=("instrument", "visi
         lookupFunction=partial(lookupBiasDark, allowEmpty=True),
         minimum=0,  # allowed to not exist, since we may use dark instead
     )
+    badRefPixels = PrerequisiteConnection(
+        name="badRefPixels",
+        doc="Bad IRP reference-row pixels (per-detector)",
+        storageClass="NirBadRefPixels",
+        dimensions=["instrument", "arm", "spectrograph"],
+        isCalibration=True,
+        minimum=0,  # only required for NIR when h4.doIRPbadPixels
+    )
     flat = PrerequisiteConnection(
         name="fiberFlat",
         doc="Combined flat",
@@ -538,6 +545,8 @@ class PfsIsrConnections(PipelineTaskConnections, dimensions=("instrument", "visi
         if config.doDark is not True:
             self.prerequisiteInputs.remove("dark")
             self.prerequisiteInputs.remove("nirDark")
+        if config.h4.doIRPbadPixels is not True:
+            self.prerequisiteInputs.remove("badRefPixels")
         if config.doFlat is not True:
             self.prerequisiteInputs.remove("flat")
         if config.doFringe is not True:
@@ -1040,6 +1049,7 @@ class PfsIsrTask(ipIsr.IsrTask):
         defects=None,
         detectorNum=None,
         ipcCoeffs=None,
+        badRefPixels=None,
         **kwargs,
     ):
         """Specialist instrument signature removal for H4RG detectors
@@ -1081,6 +1091,9 @@ class PfsIsrTask(ipIsr.IsrTask):
 
                 if k in ("crosstalk", "crosstalkSources", "linearizer"):
                     self.log.warn("Unexpected argument for runH4RG: %s", k)
+
+        # Stash for correctBadIrpPixels(), which is reached deep in the ramp path.
+        self._badRefPixels = badRefPixels
 
         if self.config.doDark:
             if self.config.h4.useDarkCube:
@@ -1758,23 +1771,15 @@ class PfsIsrTask(ipIsr.IsrTask):
         # what to do about that, but return the indices of both.
         return deltas, posIdx, negIdx
 
-    def loadBadIRPpixels(self, detectorName: str) -> np.ndarray:
-        """Return the bad IRP row pixel list."""
+    def getBadIRPpixels(self) -> np.ndarray:
+        """Return the bad IRP row pixel list from the butler-provided calib."""
 
-        filename = 'badRefPixels.yaml'
-        absFilename = os.path.join(getPackageDir("drp_pfs_data"), "h4", filename)
-        if not os.path.exists(absFilename):
-            self.log.warn(f'{absFilename} not found')
+        calib = getattr(self, "_badRefPixels", None)
+        if calib is None:
+            self.log.warn('no badRefPixels calib available; skipping bad-IRP-pixel repair')
             return np.zeros(dtype=np.int16, shape=())
 
-        with open(absFilename) as f:
-            cfg = yaml.YAML(typ="safe", pure=True).load(f)
-
-        if detectorName not in cfg:
-            self.log.warn(f'{detectorName} not defined in {absFilename}')
-            return np.zeros(dtype=np.int16, shape=())
-
-        return np.array(cfg[detectorName])
+        return np.asarray(calib.pixels, dtype=np.int32)
 
     def correctBadIrpPixels(self, pfsRaw, refImg):
         """Given an IRP1 image, interpolate over known bad IRP row pixels.
@@ -1795,7 +1800,7 @@ class PfsIsrTask(ipIsr.IsrTask):
             warnings.warn('Do not know how to correct for bad IRP pixels in non-IRP1 images')
             return
 
-        badPixels = self.loadBadIRPpixels(pfsRaw.detector.getName())
+        badPixels = self.getBadIRPpixels()
 
         # We really want to be doing this on IRP diffs, given the huge common per-pixel offsets.
         # If not, need to somehow flatten out those offsets.

--- a/python/lsst/obs/pfs/nirBadRefPixels.py
+++ b/python/lsst/obs/pfs/nirBadRefPixels.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import numpy as np
+import astropy.io.fits
+
+from lsst.daf.base import PropertyList
+
+from pfs.datamodel.utils import astropyHeaderFromDict
+
+__all__ = ("NirBadRefPixels",)
+
+
+class NirBadRefPixels:
+    """Bad IRP reference-row pixel list for a single NIR (H4RG) detector.
+
+    Consists of a header-only primary HDU and a ``BADPIX`` binary table HDU
+    with a single integer column ``PIXEL`` holding the row-pixel indices that
+    are bad in the Interleaved Reference Pixel (IRP) data.
+
+    Parameters
+    ----------
+    pixels : `np.ndarray`, 1-D int
+        Row-pixel indices that are bad in the IRP.
+    metadata : `lsst.daf.base.PropertyList`, optional
+        Metadata (FITS header); carries e.g. the detector name (``DETNAME``).
+    """
+
+    def __init__(self, pixels: np.ndarray, metadata: "PropertyList | None" = None) -> None:
+        self.pixels = np.asarray(pixels, dtype=np.int32).ravel()
+        self.metadata = metadata if metadata is not None else PropertyList()
+
+    @classmethod
+    def fromList(cls, pixels, detectorName: "str | None" = None) -> "NirBadRefPixels":
+        """Construct from a list of pixel indices
+
+        Parameters
+        ----------
+        pixels : iterable of `int`
+            Row-pixel indices that are bad in the IRP.
+        detectorName : `str`, optional
+            Detector name, recorded in the metadata as ``DETNAME``.
+
+        Returns
+        -------
+        self : `NirBadRefPixels`
+            The bad reference-pixel list.
+        """
+        metadata = PropertyList()
+        if detectorName is not None:
+            metadata.set("DETNAME", detectorName)
+        return cls(np.array(pixels, dtype=np.int32), metadata)
+
+    @classmethod
+    def fromFits(cls, fits: astropy.io.fits.HDUList) -> "NirBadRefPixels":
+        """Construct from a FITS file
+
+        Parameters
+        ----------
+        fits : `astropy.io.fits.HDUList`
+            The FITS file.
+
+        Returns
+        -------
+        self : `NirBadRefPixels`
+            The bad reference-pixel list.
+        """
+        metadata = PropertyList.from_mapping(fits[0].header)
+        hdu = fits["BADPIX"]
+        if hdu.data is None:
+            pixels = np.zeros(0, dtype=np.int32)
+        else:
+            pixels = np.asarray(hdu.data["PIXEL"], dtype=np.int32)
+        return cls(pixels, metadata)
+
+    def toFits(self) -> astropy.io.fits.HDUList:
+        """Write to a FITS file
+
+        Returns
+        -------
+        fits : `astropy.io.fits.HDUList`
+            The FITS file.
+        """
+        fits = astropy.io.fits.HDUList()
+        header = astropyHeaderFromDict(self.metadata)
+        fits.append(astropy.io.fits.PrimaryHDU(data=None, header=header))
+        column = astropy.io.fits.Column(name="PIXEL", format="J", array=self.pixels)
+        fits.append(astropy.io.fits.BinTableHDU.from_columns([column], name="BADPIX"))
+        return fits
+
+    def writeFits(self, path: str) -> None:
+        """Write the bad reference-pixel list to a FITS file
+
+        Parameters
+        ----------
+        path : `str`
+            Path to the output FITS file.
+        """
+        with open(path, "wb") as fd:
+            self.toFits().writeto(fd)
+
+    @classmethod
+    def readFits(cls, path: str) -> "NirBadRefPixels":
+        """Read the bad reference-pixel list from a FITS file
+
+        Parameters
+        ----------
+        path : `str`
+            Path to the FITS file.
+
+        Returns
+        -------
+        self : `NirBadRefPixels`
+            The bad reference-pixel list.
+        """
+        with astropy.io.fits.open(path) as fits:
+            return cls.fromFits(fits)

--- a/tests/test_makePfsCalibs.py
+++ b/tests/test_makePfsCalibs.py
@@ -1,0 +1,109 @@
+"""Integration tests for the script-installed calibration products.
+
+Builds a throwaway butler repository, exercises the ``makePfsCalibs`` install
+logic, and confirms that validity-date selection and CALIBRATION run chaining
+work for the ``defects`` and ``badRefPixels`` products.
+"""
+
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+import astropy.time
+
+from lsst.daf.butler import CollectionType, Timespan
+import lsst.utils.tests
+
+OBS_PFS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def loadScript(name):
+    """Import one of the ``bin.src`` scripts as a module."""
+    path = os.path.join(OBS_PFS_DIR, "bin.src", f"{name}.py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def utc(iso):
+    return astropy.time.Time(iso, format="isot", scale="utc")
+
+
+class MakePfsCalibsTestCase(lsst.utils.tests.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.install = loadScript("makePfsCalibs")
+        cls.root = tempfile.mkdtemp(prefix="pfsCalibs-")
+        repo = os.path.join(cls.root, "repo")
+        cls.butler = loadScript("makePfsTestRepo").makePfsTestRepo(repo)
+        cls.drpData = cls.install.getPackageDir("drp_pfs_data")
+
+        cls.collection = "u/test/PIPE2D-1856/test"
+        cls.defectsColl = f"{cls.collection}/defectsGen.99999999a"
+        cls.badRefColl = f"{cls.collection}/badRefPixelsGen.99999999a"
+        for coll in (cls.defectsColl, cls.badRefColl):
+            cls.butler.registry.registerCollection(coll, CollectionType.CALIBRATION)
+
+        cls.install.installDefects(cls.butler, cls.drpData, cls.defectsColl, "PFS")
+        cls.install.installBadRefPixels(
+            cls.butler, cls.drpData, cls.badRefColl, "PFS", begin=None, end=None
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.root, ignore_errors=True)
+
+    def findVersion(self, datasetType, dataId, collection, when):
+        timespan = Timespan(utc(when), utc(when))
+        ref = self.butler.registry.findDataset(
+            datasetType, dataId, collections=collection, timespan=timespan
+        )
+        return None if ref is None else os.path.basename(ref.run)
+
+    def testDefectsDateSelection(self):
+        """n2 defects (versions 1970, 2023-07-01, 2025-02-15) select by date."""
+        dataId = dict(instrument="PFS", detector=5)  # n2
+        self.assertEqual(
+            self.findVersion("defects", dataId, self.defectsColl, "2019-01-01T00:00:00"),
+            "19700101T000000",
+        )
+        self.assertEqual(
+            self.findVersion("defects", dataId, self.defectsColl, "2024-01-01T00:00:00"),
+            "20230701T000000",
+        )
+        self.assertEqual(
+            self.findVersion("defects", dataId, self.defectsColl, "2025-06-01T00:00:00"),
+            "20250215T000000",
+        )
+
+    def testBadRefPixelsReadback(self):
+        """badRefPixels round-trips through the butler, incl. the empty n2."""
+        now = Timespan(utc("2026-01-01T00:00:00"), utc("2026-01-01T00:00:00"))
+        n1 = self.butler.get(
+            "badRefPixels", dict(instrument="PFS", arm="n", spectrograph=1),
+            collections=self.badRefColl, timespan=now,
+        )
+        self.assertGreater(n1.pixels.size, 0)
+        self.assertEqual(n1.metadata.get("DETNAME"), "n1")
+        n2 = self.butler.get(
+            "badRefPixels", dict(instrument="PFS", arm="n", spectrograph=2),
+            collections=self.badRefColl, timespan=now,
+        )
+        self.assertEqual(n2.pixels.size, 0)
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    setup_module(sys.modules["__main__"])
+    unittest.main(failfast=True)

--- a/tests/test_nirBadRefPixels.py
+++ b/tests/test_nirBadRefPixels.py
@@ -1,0 +1,46 @@
+import sys
+import unittest
+
+import numpy as np
+
+from lsst.obs.pfs.nirBadRefPixels import NirBadRefPixels
+import lsst.utils.tests
+
+
+class NirBadRefPixelsTestCase(lsst.utils.tests.TestCase):
+    """Tests the functionality of NirBadRefPixels"""
+
+    def checkRoundTrip(self, pixels, detectorName):
+        calib = NirBadRefPixels.fromList(pixels, detectorName)
+        self.assertEqual(calib.pixels.dtype, np.int32)
+        self.assertFloatsEqual(calib.pixels, np.array(pixels, dtype=np.int32))
+        if detectorName is not None:
+            self.assertEqual(calib.metadata.get("DETNAME"), detectorName)
+
+        with lsst.utils.tests.getTempFilePath(".fits") as filename:
+            calib.writeFits(filename)
+            new = NirBadRefPixels.readFits(filename)
+            self.assertFloatsEqual(new.pixels, np.array(pixels, dtype=np.int32))
+            if detectorName is not None:
+                self.assertEqual(new.metadata.get("DETNAME"), detectorName)
+
+    def testBasic(self):
+        """Round-trip a non-empty pixel list"""
+        self.checkRoundTrip([230, 301, 342, 4033], "n1")
+
+    def testEmpty(self):
+        """Round-trip an empty pixel list (e.g. n2)"""
+        self.checkRoundTrip([], "n2")
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    setup_module(sys.modules["__main__"])
+    unittest.main(failfast=True)


### PR DESCRIPTION
## Summary

Make the `badRefPixels` and `defects` calibrations selectable by observation
date through the butler, instead of by EUPS setup of `drp_pfs_data`.

- Register `badRefPixels` and `defects` as calibration dataset types and add
  `bin.src/makePfsCalibs.py`, which reads the data files from `drp_pfs_data`,
  `butler.put`s them into a RUN and `registry.certify`s them into DMTN-222-named
  CALIBRATION collections with explicit validity dates (defects as the existing
  dated chain; configurable `--root` for testing, e.g. `u/<user>/<ticket>`).
- Add a `NirBadRefPixels` FITS class (and storage class) for the bad IRP
  reference-pixel list, split per detector from `h4/badRefPixels.yaml`.
  `PfsIsrTask` now reads `badRefPixels` from a butler prerequisite input instead
  of resolving a `getPackageDir` path.
- `defects` **keeps its curated-calibration path** (`makePfsDefects`,
  `write-curated-calibrations`) for backward compatibility with existing scripts,
  and is *additionally* certifiable through `makePfsCalibs`.
- Add `bin.src/makePfsTestRepo.py` to create a ready-to-use butler repo (PFS
  dimensions + storage classes + instrument/dataset-types registered).

## Not included

`nirLinearity` is intentionally left untouched: PIPE2D-1843 replaces its format
and machinery wholesale, so turning it into a certified calibration is deferred
to that change. This keeps PIPE2D-1856 order-independent (lands cleanly before or
after 1843). A working template against the old format is preserved at tag
`PIPE2D-1843-nirLinearity-template`.

## Testing

`scons` (build + tests + flake8): 13 passed, linting clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)