### PR TITLE
PIPE2D-1664: Add NIR combined dark (nirDark) generation

### DIFF
--- a/bin.src/combineNirDark.py
+++ b/bin.src/combineNirDark.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+"""Combine N raw NIR dark ramps into a single master nirDark ramp.
+
+Reads the per-visit ``rawISRCube`` ramps for the given dark visits from the
+input collection, median-combines them read-by-read (correcting per-read offsets
+between ramps), puts the result into a RUN collection and certifies it into a
+CALIBRATION collection, so that the pipeline selects it by observation date. The
+output dataset type is chosen from the IRP ratio of the input ramps: ``nirDark``
+for the default (IRP1) or ``nirDark_irp<N>`` (e.g. ``nirDark_irp4``) otherwise.
+
+Collections follow the DMTN-222 convention (https://dmtn-222.lsst.io), as the
+pipeline-generated ``dark`` and ``bias`` do. Under the ``--output`` base, with
+``{iteration}`` a ``YYYYMMDDv`` date string:
+
+- ``{output}/{ticket}/{tag}/{product}.{iteration}`` -- CALIBRATION, certified
+  into, and what the pipeline selects the dark from;
+- ``{output}/{ticket}/{tag}/{product}Gen.{iteration}`` -- CHAINED, gathering this
+  generation's run and its input;
+- ``{output}/{ticket}/{tag}/{product}Gen.{iteration}/{YYYYMMDDTHHMMSSZ}`` -- the
+  RUN holding the datasets. Each attempt gets its own timestamped RUN, so a retry
+  after a failed write does not collide with the previous one.
+
+Only those three collections are written. Shared chains such as ``PFS/calib`` are
+maintained by hand and are never touched; promoting a dark into one is a separate
+step (see ``copyDatasets.py``).
+
+By default all four NIR spectrographs are reduced in parallel, one worker
+process each. The output collections and dataset type are named and registered
+before any combine starts, and each combined dark is written to ``--save-dir``
+as a plain FITS file before it is put to the butler.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import datetime
+import logging
+import os
+from argparse import ArgumentParser
+
+from lsst.obs.pfs import nirSuperdark
+
+
+def parseVisitRange(token: str) -> list[int]:
+    """Expand a single visit token into a list of visit ids.
+
+    Accepts a plain integer (``"1234"``) or an LSST-style inclusive range
+    ``"BEGIN..END"`` with an optional step ``"BEGIN..END:STEP"`` (e.g.
+    ``"144784..144808"`` or ``"144784..144808:2"``).
+    """
+    if ".." not in token:
+        return [int(token)]
+    rangePart, _, stepPart = token.partition(":")
+    try:
+        beginStr, endStr = rangePart.split("..")
+        begin, end = int(beginStr), int(endStr)
+        step = int(stepPart) if stepPart else 1
+    except ValueError:
+        raise ValueError(f"malformed visit range {token!r}; expected BEGIN..END[:STEP]")
+    if step <= 0:
+        raise ValueError(f"step must be positive in visit range {token!r}")
+    if end < begin:
+        raise ValueError(f"range end precedes begin in visit range {token!r}")
+    return list(range(begin, end + 1, step))
+
+
+def parseVisits(tokens: list[str]) -> list[int]:
+    """Expand a list of visit tokens (ints and/or ranges) into visit ids."""
+    visits: list[int] = []
+    for token in tokens:
+        visits.extend(parseVisitRange(token))
+    return visits
+
+
+def reduceSpectrographs(repo: str, inputRun: str, outputBase: str,
+                        spectrographs: list[int], visits: list[int],
+                        ticket: str, tag: str, iteration: str, timestamp: str,
+                        startDate=None,
+                        processes: int | None = None,
+                        saveDir: str | None = None) -> None:
+    """Reduce each spectrograph's NIR dark, in parallel across worker processes.
+
+    Each spectrograph is an independent reduction (its own dataId and output
+    dataset), so they run concurrently. ``processes`` defaults to one worker per
+    spectrograph; pass a smaller number to cap memory use, since each reduction
+    holds the full ramp stack in memory. Failures are collected so that a problem
+    with one spectrograph does not abandon the others; a `RuntimeError`
+    summarizing them is raised once all have been attempted.
+
+    The collections, the dataset type, the RUN timestamp, and the validity start
+    date are resolved once, here in the parent, before any worker starts: a combine
+    takes hours, so it must not be a butler misconfiguration that discovers itself
+    at the end. Doing it once also keeps the four workers from racing to register
+    the same things, gives the whole dark set a single validity start rather than
+    one per detector's timestamp, and puts all four spectrographs in one RUN.
+    """
+    dataIds = [dict(instrument="PFS", arm="n", spectrograph=s) for s in spectrographs]
+    processes = len(dataIds) if processes is None else processes
+    processes = max(1, min(processes, len(dataIds)))
+
+    plan = nirSuperdark.preflight(inputRun, outputBase, dataIds[0], visits,
+                                  ticket, tag, iteration, timestamp, repo_path=repo)
+    if startDate is None:
+        startDate = plan.startDate
+    logger = logging.getLogger(__name__)
+    logger.info("will write %s for spectrograph(s) %s", plan.datasetType,
+                ", ".join(str(s) for s in spectrographs))
+    logger.info("  run       %s", plan.outputRun)
+    logger.info("  chain     %s", plan.genCollection)
+    logger.info("  certify   %s from %s", plan.calibCollection, startDate)
+    if saveDir is not None:
+        os.makedirs(saveDir, exist_ok=True)
+
+    kwargs = dict(startDate=startDate, repo_path=repo,
+                  saveDir=saveDir, calibCollection=plan.calibCollection)
+    outputRun = plan.outputRun
+
+    errors = []
+    if processes == 1:
+        for dataId in dataIds:
+            try:
+                nirSuperdark.processMasterDark(inputRun, outputRun, dataId, visits,
+                                               **kwargs)
+            except Exception as exc:
+                errors.append((dataId["spectrograph"], exc))
+    else:
+        with concurrent.futures.ProcessPoolExecutor(max_workers=processes) as pool:
+            futures = {}
+            for dataId in dataIds:
+                future = pool.submit(nirSuperdark.processMasterDark, inputRun,
+                                     outputRun, dataId, visits, **kwargs)
+                futures[future] = dataId["spectrograph"]
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    future.result()
+                except Exception as exc:
+                    errors.append((futures[future], exc))
+
+    if errors:
+        summary = "; ".join(f"n{s}: {exc}" for s, exc in sorted(errors))
+        raise RuntimeError(
+            f"dark reduction failed for {len(errors)} of {len(dataIds)} "
+            f"spectrograph(s): {summary}")
+
+
+def main():
+    # Configure logging before the worker pool is created so forked workers
+    # inherit it and their per-read progress lines reach the terminal.
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s",
+                        datefmt="%H:%M:%S")
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("repo", help="Path to the butler repository")
+    parser.add_argument("--input", required=True,
+                        help="Input collection holding the per-visit rawISRCubes")
+    parser.add_argument("--output", required=True,
+                        help="Collection base the DMTN-222 output collections are "
+                             "composed under, e.g. u/<user>/calib or PFS/calib")
+    parser.add_argument("--ticket", required=True, help="Ticket name, e.g. PIPE2D-1664")
+    parser.add_argument("--tag", required=True, help="Tag/label for this calibration set")
+    parser.add_argument("--iteration", default=None,
+                        help="DMTN-222 rerun iteration (YYYYMMDDv); default: today + 'a'")
+    parser.add_argument("--run-timestamp", default=None, dest="timestamp",
+                        help="Timestamp naming the output RUN within the generation "
+                             "chain (YYYYMMDDTHHMMSSZ); default: now, in UTC")
+    parser.add_argument("--save-dir", default=".", dest="saveDir",
+                        help="Directory to write the combined dark to as a plain FITS "
+                             "file before putting it to the butler, so a butler failure "
+                             "does not discard hours of work (default: current directory)")
+    parser.add_argument("--spectrograph", type=int, nargs="+", default=[1, 2, 3, 4],
+                        help="Spectrograph number(s) to process (default: all four)")
+    parser.add_argument("--visits", nargs="+", required=True,
+                        help="Dark visits to combine: integers and/or LSST-style "
+                             "inclusive ranges BEGIN..END[:STEP] (e.g. 144784..144808)")
+    parser.add_argument("--start-date", default=None, dest="startDate",
+                        type=datetime.datetime.fromisoformat,
+                        help="ISO-8601 start of the calibration's open-ended validity "
+                             "period (default: the date of the first visit)")
+    parser.add_argument("--processes", type=int, default=None,
+                        help="Number of parallel worker processes "
+                             "(default: one per spectrograph)")
+    args = parser.parse_args()
+
+    iteration = args.iteration
+    if iteration is None:
+        iteration = nirSuperdark.defaultIteration()
+    timestamp = args.timestamp
+    if timestamp is None:
+        timestamp = nirSuperdark.defaultTimestamp()
+
+    reduceSpectrographs(args.repo, args.input, args.output, args.spectrograph,
+                        parseVisits(args.visits), args.ticket, args.tag, iteration,
+                        timestamp, startDate=args.startDate, processes=args.processes,
+                        saveDir=args.saveDir)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin.src/copyDatasets.py
+++ b/bin.src/copyDatasets.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+"""Copy or link datasets between collections in a butler repository.
+
+A dataset's RUN collection is immutable, so there is no butler move or rename,
+and ``butler transfer-datasets`` only transfers between distinct repositories.
+This script copies each dataset's file and ingests it under a fresh dataset ID in
+``--output-run``, which is the only way to re-home a dataset within one
+repository.
+
+Its intended use is promoting a calibration from a personal collection into the
+shared one, e.g. from ``u/<user>/calib/<ticket>/...`` to ``PFS/calib/<ticket>/...``:
+
+    copyDatasets.py /work/datastore \\
+        --input u/cpl/calib/PIPE2D-1664/irp4/nirDark_irp4Gen.20260709a/put \\
+        --dataset-type nirDark_irp4 \\
+        --output-run PFS/calib/PIPE2D-1664/irp4/nirDark_irp4Gen.20260709a/put \\
+        --certify PFS/calib/PIPE2D-1664/irp4/nirDark_irp4Gen.20260709a
+
+With ``--certify`` and no ``--begin-date``, the validity period is inherited from
+the source certification, so it need not be restated.
+
+Pass ``--no-copy`` to certify the datasets where they already are, without
+duplicating the pixels. That leaves the destination CALIBRATION collection
+referencing the source RUN, which must then not be pruned.
+"""
+
+from __future__ import annotations
+
+import logging
+from argparse import ArgumentParser
+
+from lsst.daf.butler import Butler
+
+from lsst.obs.pfs import datasetCopy
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s",
+                        datefmt="%H:%M:%S")
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("repo", help="Path to the butler repository")
+    parser.add_argument("--input", nargs="+", required=True, dest="inputCollections",
+                        help="Collection(s) to take the datasets from")
+    parser.add_argument("--dataset-type", nargs="+", required=True, dest="datasetTypes",
+                        help="Dataset type name(s) to copy")
+    parser.add_argument("--output-run", default=None, dest="outputRun",
+                        help="RUN collection to copy the datasets into; created if absent")
+    parser.add_argument("--no-copy", action="store_true", dest="noCopy",
+                        help="Leave the datasets in their existing RUN instead of copying "
+                             "them. Requires --certify, and makes the certified collection "
+                             "depend on the source RUN surviving")
+    parser.add_argument("--certify", default=None, dest="calibCollection",
+                        help="CALIBRATION collection to certify the results into")
+    parser.add_argument("--begin-date", default=None, dest="beginDate",
+                        help="ISO-8601 TAI start of the validity period "
+                             "(default: inherited from the source certification)")
+    parser.add_argument("--end-date", default=None, dest="endDate",
+                        help="ISO-8601 TAI end of the validity period (default: open-ended)")
+    parser.add_argument("--where", default="",
+                        help="Butler query expression restricting which datasets are copied")
+    parser.add_argument("--transfer", default="copy", dest="transferMode",
+                        choices=["copy", "hardlink", "symlink", "relsymlink", "link",
+                                 "move", "direct", "auto"],
+                        help="How to transfer the file artifact. Only 'copy' (the "
+                             "default) leaves the destination independent of the source")
+    parser.add_argument("--skip-existing", action="store_true", dest="skipExisting",
+                        help="Skip datasets already present in the output run, so an "
+                             "interrupted copy can be resumed")
+    parser.add_argument("--allow-intermediates", action="store_true", dest="allowIntermediates",
+                        help="Permit copying an intermediate product such as rawISRCube, "
+                             "which is refused by default")
+    parser.add_argument("--dry-run", action="store_true", dest="dryRun",
+                        help="Report what would be done without writing anything")
+    args = parser.parse_args()
+
+    if args.noCopy:
+        if args.outputRun is not None:
+            parser.error("--no-copy leaves the datasets in place; do not pass --output-run")
+        if args.calibCollection is None:
+            parser.error("--no-copy does nothing without --certify")
+    elif args.outputRun is None:
+        parser.error("--output-run is required unless --no-copy is given")
+
+    butler = Butler.from_config(args.repo, writeable=not args.dryRun)
+    datasetCopy.transfer(butler, args.datasetTypes, args.inputCollections,
+                         outputRun=args.outputRun, where=args.where,
+                         calibCollection=args.calibCollection,
+                         beginDate=args.beginDate, endDate=args.endDate,
+                         skipExisting=args.skipExisting, transferMode=args.transferMode,
+                         allowIntermediates=args.allowIntermediates, dryRun=args.dryRun)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin.src/makeNirRawCubes.py
+++ b/bin.src/makeNirRawCubes.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+"""Generate the raw NIR ramp cubes (``rawISRCube``) that combineNirDark consumes.
+
+Runs the ``isr`` step of ``reduceExposure.yaml`` over the given NIR visits with
+the corrections that a dark must *not* have applied: no dark subtraction, no
+flat, no linearity, and no IRP smoothing. The point of a nirDark is to capture
+the full raw instrument dark signature, which is subtracted from an exposure ramp
+before any corrections, so the ramps it is built from must themselves be raw.
+
+The overridden configuration, and the default it replaces:
+
+===============================  ========  =====
+Config                           Default   Here
+===============================  ========  =====
+``isr.doDark``                   True      False
+``isr.doFlat``                   True      False
+``isr.h4.doWriteRawCube``        False     True
+``isr.h4.doLinearize``           True      False
+``isr.h4.quickCDS``              False     False
+===============================  ========  =====
+
+Reference-pixel handling is selectable: ``--irp-filter`` sets ``isr.h4.IRPfilter``
+(default 0 = use IRP with no smoothing; -1 = per-column median; odd 15..31 =
+Hann-smoothed), and ``--no-irp`` sets ``isr.h4.useIRP=False`` to bypass the IRP
+planes entirely and border-correct instead. The dark must be built the same way
+as the exposures it will be subtracted from.
+
+Like ``combineNirDark.py``, ``--output`` is a collection base beneath which the
+DMTN-222 layout is composed: the cubes go to a ``scratchCubes`` output collection
+at ``{output}/{ticket}/{tag}/scratchCubes``. They are an intermediate product, not
+a calibration, so they get no ``Gen.{iteration}`` name and are not certified.
+Pipetask makes that a CHAINED collection and writes a timestamped RUN inside it,
+so re-running does not collide; pass the chain straight to ``combineNirDark
+--input``.
+
+Example, reproducing the IRP1 nirDark inputs::
+
+    makeNirRawCubes.py /work/datastore \\
+        --input u/cpl/calib/PIPE2D-1858/PIPE2D-1857/badRefPixelsGen.20000101a \\
+        --output u/cpl/calib --ticket PIPE2D-1664 --tag irp1 \\
+        --visits 144587..144636 -j 12
+
+writes to ``u/cpl/calib/PIPE2D-1664/irp1/scratchCubes``.
+
+``--show config`` (or ``--show uri``) is passed through to pipetask, and reports
+the resolved configuration without running anything.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from argparse import ArgumentParser
+
+from lsst.utils import getPackageDir
+
+# The corrections a raw dark ramp must not have had applied, independent of how
+# the reference pixels are handled. quickCDS is already the default, but is set
+# explicitly: these ramps are defined by their processing.
+ISR_CONFIG = (
+    "isr:doDark=False",
+    "isr:doFlat=False",
+    "isr:h4.doWriteRawCube=True",
+    "isr:h4.quickCDS=False",
+    "isr:h4.doLinearize=False",
+)
+
+# The default IRP smoothing: use IRP planes with no smoothing, matching the
+# nirDark recipe. `IRPfilter=0` = no smoothing; -1 = per-column median; odd
+# 15..31 = Hann-smoothed. `useIRP=False` bypasses IRP for border correction.
+DEFAULT_IRP_FILTER = 0
+
+DEFAULT_INPUTS = ("PFS/defaults",)
+
+
+def irpConfig(irpFilter: int, useIRP: bool) -> tuple[str, ...]:
+    """The reference-pixel config overrides.
+
+    ``useIRP`` is always stated explicitly; ``IRPfilter`` is emitted only when IRP
+    is in use, since it does nothing when the reference planes are bypassed.
+    """
+    overrides = [f"isr:h4.useIRP={useIRP}"]
+    if useIRP:
+        overrides.append(f"isr:h4.IRPfilter={irpFilter}")
+    return tuple(overrides)
+
+
+def scratchCollection(outputBase: str, ticket: str, tag: str) -> str:
+    """The output collection for the raw cubes, within the DMTN-222 layout.
+
+    The cubes are an intermediate product rather than a calibration, so they get
+    no ``{product}Gen.{iteration}`` name. Pipetask makes this a CHAINED collection
+    and writes a timestamped RUN into it, so repeated runs do not collide.
+    """
+    return f"{outputBase}/{ticket}/{tag}/scratchCubes"
+
+
+def visitQuery(visits: list[str], spectrographs: list[int] | None = None) -> str:
+    """Build the pipetask data-id expression selecting the NIR dark visits.
+
+    ``visits`` are passed through to the butler query verbatim, so both plain
+    integers and LSST-style ranges (``144587..144636``, optionally ``:STEP``)
+    work, as the butler understands both.
+    """
+    query = f"visit in ({', '.join(visits)}) and arm='n'"
+    if spectrographs:
+        query += f" and spectrograph in ({', '.join(str(s) for s in spectrographs)})"
+    return query
+
+
+def pipelinePath() -> str:
+    """The ``isr`` subset of drp_stella's reduceExposure pipeline."""
+    return f"{getPackageDir('drp_stella')}/pipelines/reduceExposure.yaml#isr"
+
+
+def buildCommand(repo: str, inputs: list[str], output: str, visits: list[str],
+                 spectrographs: list[int] | None = None,
+                 processes: int = 1, logLevel: str | None = None,
+                 irpFilter: int = DEFAULT_IRP_FILTER, useIRP: bool = True,
+                 config: list[str] | None = None,
+                 show: list[str] | None = None) -> list[str]:
+    """Assemble the ``pipetask run`` command line."""
+    command = ["pipetask", "--long-log"]
+    if logLevel:
+        command += ["--log-level", logLevel]
+    command += [
+        "run",
+        "-b", repo,
+        "-i", ",".join(inputs),
+        "-o", output,
+        "-p", pipelinePath(),
+        "--fail-fast",
+        "-j", str(processes),
+        "-d", visitQuery(visits, spectrographs),
+    ]
+    for override in ISR_CONFIG + irpConfig(irpFilter, useIRP) + tuple(config or ()):
+        command += ["-c", override]
+    for item in show or ():
+        command += ["--show", item]
+    return command
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("repo", help="Path to the butler repository")
+    parser.add_argument("--input", nargs="+", required=True, dest="inputs",
+                        help="Input collection(s); PFS/defaults is appended if absent")
+    parser.add_argument("--output", required=True,
+                        help="Collection base the output is composed under, "
+                             "e.g. u/<user>/calib or PFS/calib")
+    parser.add_argument("--ticket", required=True, help="Ticket name, e.g. PIPE2D-1664")
+    parser.add_argument("--tag", required=True, help="Tag/label for this set of cubes")
+    parser.add_argument("--output-collection", default=None, dest="outputCollection",
+                        help="Write here instead of {output}/{ticket}/{tag}/scratchCubes")
+    parser.add_argument("--visits", nargs="+", required=True,
+                        help="Dark visits: integers and/or LSST-style inclusive ranges "
+                             "BEGIN..END[:STEP] (e.g. 144587..144636)")
+    parser.add_argument("--spectrograph", type=int, nargs="+", default=None,
+                        help="Spectrograph number(s) (default: all)")
+    parser.add_argument("-j", "--processes", type=int, default=1,
+                        help="Number of pipetask worker processes (default: 1)")
+    parser.add_argument("--irp-filter", type=int, default=DEFAULT_IRP_FILTER, dest="irpFilter",
+                        help="IRP smoothing window: 0=none (default), -1=per-column median, "
+                             "odd 15..31=Hann-smoothed. Ignored with --no-irp")
+    parser.add_argument("--no-irp", action="store_false", dest="useIRP",
+                        help="Bypass the interleaved reference pixels entirely and "
+                             "border-correct instead (isr:h4.useIRP=False)")
+    parser.add_argument("--log-level", default=None, dest="logLevel",
+                        help="pipetask --log-level, e.g. .=DEBUG")
+    parser.add_argument("-c", "--config", action="append", default=None,
+                        help="Extra pipetask config override, e.g. isr:h4.doCR=True. "
+                             "Repeatable; applied after the raw-cube overrides")
+    parser.add_argument("--show", action="append", default=None,
+                        help="Passed to pipetask, e.g. 'config' or 'uri'. Reports the "
+                             "resolved configuration without processing anything. "
+                             "Repeatable")
+    parser.add_argument("--dry-run", action="store_true", dest="dryRun",
+                        help="Print the pipetask command without running it")
+    args = parser.parse_args()
+
+    inputs = list(args.inputs)
+    for default in DEFAULT_INPUTS:
+        if default not in inputs:
+            inputs.append(default)
+
+    output = args.outputCollection
+    if output is None:
+        output = scratchCollection(args.output, args.ticket, args.tag)
+
+    command = buildCommand(args.repo, inputs, output, args.visits,
+                           spectrographs=args.spectrograph, processes=args.processes,
+                           irpFilter=args.irpFilter, useIRP=args.useIRP,
+                           logLevel=args.logLevel, config=args.config, show=args.show)
+    if args.dryRun:
+        # shlex.join, so the printed command can be pasted into a shell: the
+        # data-id expression contains spaces and quotes.
+        print(shlex.join(command))
+        return
+    sys.exit(subprocess.call(command))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/lsst/obs/pfs/PrimeFocusSpectrograph.py
+++ b/python/lsst/obs/pfs/PrimeFocusSpectrograph.py
@@ -149,6 +149,16 @@ class PrimeFocusSpectrograph(Instrument):
             "ImageCube",
             True,
         )
+        # IRP4 dark: same product as nirDark, built from IRP-ratio-4 ramps. The
+        # dark is subtracted read-by-read, and the IRP ratio changes the per-read
+        # cadence, so it needs its own dataset type. (Also defined in PIPE2D-1855.)
+        self.registerDatasetType(
+            registry,
+            "nirDark_irp4",
+            ["instrument", "arm", "spectrograph"],
+            "ImageCube",
+            True,
+        )
         self.registerDatasetType(
             registry,
             "badRefPixels",

--- a/python/lsst/obs/pfs/datasetCopy.py
+++ b/python/lsst/obs/pfs/datasetCopy.py
@@ -1,0 +1,280 @@
+"""Copy or link datasets between collections within one butler repository.
+
+A dataset's RUN collection is immutable: the butler offers no move or rename, and
+``Butler.transfer_from`` is a no-op when its source and destination are the same
+repository. The only way to re-home a dataset is to give its file a new dataset
+ID under a new RUN, which is what `copyDatasets` does.
+
+Where a genuine copy is not wanted, `linkDatasets` leaves the datasets in the RUN
+they were written to. Either way, calibrations may then be certified into a
+CALIBRATION collection with `certifyDatasets`, which is what makes the pipeline
+select them by observation date.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import astropy.time
+
+from lsst.daf.butler import Butler, CollectionType, DatasetRef, FileDataset, Timespan
+from lsst.daf.butler.registry import ConflictingDefinitionError, MissingCollectionError
+
+logger = logging.getLogger(__name__)
+
+# Bulky intermediates that exist only to be consumed by a later step. Promoting
+# them into a shared collection is almost always a mistake, so copying one has to
+# be asked for explicitly.
+INTERMEDIATE_DATASET_TYPES = frozenset({"rawISRCube"})
+
+
+def findDatasets(butler: Butler,
+                 datasetTypes: list[str],
+                 inputCollections: list[str],
+                 where: str = "") -> list[DatasetRef]:
+    """Find the datasets to copy or link.
+
+    Only the first match of each dataset type and dataId is returned, so a
+    CHAINED input collection resolves the way the pipeline would resolve it.
+    """
+    refs: list[DatasetRef] = []
+    for datasetType in datasetTypes:
+        found = butler.query_datasets(datasetType, collections=inputCollections,
+                                      find_first=True, where=where, explain=False)
+        logger.info("found %d %s dataset(s) in %s",
+                    len(found), datasetType, ", ".join(inputCollections))
+        refs.extend(found)
+    if not refs:
+        raise RuntimeError(
+            f"no datasets of type(s) {', '.join(datasetTypes)} found in "
+            f"{', '.join(inputCollections)}"
+            + (f" matching {where!r}" if where else "")
+        )
+    return refs
+
+
+def ensureRun(butler: Butler, outputRun: str) -> None:
+    """Make sure ``outputRun`` exists and is a RUN collection."""
+    registry = butler.registry
+    try:
+        collectionType = registry.getCollectionType(outputRun)
+    except MissingCollectionError:
+        registry.registerCollection(outputRun, CollectionType.RUN)
+        logger.info("registered RUN collection %s", outputRun)
+    else:
+        if collectionType is not CollectionType.RUN:
+            raise ValueError(f"output collection {outputRun!r} is of type "
+                             f"{collectionType.name}; a RUN collection is required")
+
+
+def artifactUri(butler: Butler, ref: DatasetRef):
+    """The single file backing a dataset.
+
+    Raises
+    ------
+    NotImplementedError
+        If the dataset is stored as a disassembled composite, which has no single
+        artifact to copy.
+    """
+    uris = butler.getURIs(ref)
+    if uris.componentURIs:
+        raise NotImplementedError(
+            f"{ref.datasetType.name} {ref.dataId} is stored as a disassembled composite "
+            f"({len(uris.componentURIs)} components); copying it is not supported")
+    return uris.primaryURI
+
+
+def copyDatasets(butler: Butler,
+                 refs: list[DatasetRef],
+                 outputRun: str,
+                 skipExisting: bool = False,
+                 transferMode: str = "copy") -> dict[DatasetRef, DatasetRef]:
+    """Copy datasets into a new RUN collection, returning a source -> copy mapping.
+
+    The file backing each dataset is copied and ingested under a fresh dataset ID,
+    so the result does not depend on the source collection surviving.
+
+    The obvious ``butler.put(butler.get(ref))`` is wrong here. It round-trips the
+    data through the storage class, which for `ImageCube` silently drops every
+    image -- `ImageCube.writeFits` only writes images that were explicitly read or
+    set, and a freshly-fetched cube has none. It would also deserialize a
+    multi-gigabyte NIR dark ramp merely to serialize it again. Copying the
+    artifact is byte-exact and cheap.
+
+    Parameters
+    ----------
+    skipExisting : `bool`
+        Skip datasets already present in ``outputRun`` rather than failing, so
+        that an interrupted copy can be resumed.
+    transferMode : `str`
+        How to transfer the file: ``copy`` (the default, and the only mode that
+        leaves the destination independent of the source), or any other mode
+        `Butler.ingest` accepts, such as ``hardlink`` or ``direct``.
+    """
+    ensureRun(butler, outputRun)
+    copied: dict[DatasetRef, DatasetRef] = {}
+    for i, ref in enumerate(refs, 1):
+        existing = butler.query_datasets(ref.datasetType, collections=[outputRun],
+                                         data_id=ref.dataId, explain=False, limit=1)
+        if existing:
+            if not skipExisting:
+                raise ConflictingDefinitionError(
+                    f"{ref.datasetType.name} {ref.dataId} already exists in {outputRun}; "
+                    "pass skipExisting to resume an interrupted copy")
+            logger.info("[%d/%d] %s %s already in %s; skipping",
+                        i, len(refs), ref.datasetType.name, ref.dataId, outputRun)
+            copied[ref] = existing[0]
+            continue
+        newRef = DatasetRef(ref.datasetType, ref.dataId, run=outputRun)
+        butler.ingest(FileDataset(path=artifactUri(butler, ref), refs=[newRef]),
+                      transfer=transferMode)
+        logger.info("[%d/%d] copied %s %s -> %s",
+                    i, len(refs), ref.datasetType.name, ref.dataId, outputRun)
+        copied[ref] = newRef
+    return copied
+
+
+def linkDatasets(butler: Butler, refs: list[DatasetRef]) -> dict[DatasetRef, DatasetRef]:
+    """Use the datasets where they already are, without copying them.
+
+    The datasets keep their existing RUN, so anything certifying them stays
+    dependent on that RUN continuing to exist.
+    """
+    for ref in refs:
+        logger.info("linking %s %s in %s", ref.datasetType.name, ref.dataId, ref.run)
+    return {ref: ref for ref in refs}
+
+
+def sourceTimespans(butler: Butler,
+                    refs: list[DatasetRef],
+                    inputCollections: list[str]) -> dict[DatasetRef, Timespan]:
+    """Read back the validity timespans the datasets were certified with.
+
+    Used when promoting an already-certified calibration, so that its validity
+    period need not be restated. Only CALIBRATION collections carry timespans.
+
+    Raises
+    ------
+    RuntimeError
+        If any of ``refs`` is not certified in ``inputCollections``.
+    """
+    # queryDatasetAssociations is the only route to a dataset's timespan; its own
+    # docstring calls it a placeholder, so it is confined to this function.
+    wanted = {ref.id: ref for ref in refs}
+    found: dict[DatasetRef, Timespan] = {}
+    for datasetType in {ref.datasetType.name for ref in refs}:
+        for assoc in butler.registry.queryDatasetAssociations(
+                datasetType, collections=inputCollections,
+                collectionTypes=[CollectionType.CALIBRATION], flattenChains=True):
+            if assoc.ref.id in wanted and assoc.timespan is not None:
+                found[wanted[assoc.ref.id]] = assoc.timespan
+    missing = [ref for ref in refs if ref not in found]
+    if missing:
+        raise RuntimeError(
+            f"{len(missing)} dataset(s) are not certified in "
+            f"{', '.join(inputCollections)}, so their validity period cannot be "
+            "inherited; pass an explicit begin date. First: "
+            f"{missing[0].datasetType.name} {missing[0].dataId}")
+    return found
+
+
+def certifyDatasets(butler: Butler,
+                    calibCollection: str,
+                    timespans: dict[DatasetRef, Timespan]) -> None:
+    """Certify datasets into a CALIBRATION collection with their timespans.
+
+    Datasets sharing a timespan are certified together.
+    """
+    if butler.registry.registerCollection(calibCollection, CollectionType.CALIBRATION):
+        logger.info("registered CALIBRATION collection %s", calibCollection)
+
+    grouped: dict[Timespan, list[DatasetRef]] = {}
+    for ref, timespan in timespans.items():
+        grouped.setdefault(timespan, []).append(ref)
+    with butler.transaction():
+        for timespan, group in grouped.items():
+            butler.registry.certify(calibCollection, group, timespan)
+            logger.info("certified %d dataset(s) into %s for %s",
+                        len(group), calibCollection, timespan)
+
+
+def isoTai(value: str | None) -> astropy.time.Time | None:
+    """Parse an ISO-8601 TAI string into a `~astropy.time.Time` (or `None`)."""
+    if value is None:
+        return None
+    return astropy.time.Time(value, format="isot", scale="tai")
+
+
+def transfer(butler: Butler,
+             datasetTypes: list[str],
+             inputCollections: list[str],
+             outputRun: str | None = None,
+             where: str = "",
+             calibCollection: str | None = None,
+             beginDate: str | None = None,
+             endDate: str | None = None,
+             skipExisting: bool = False,
+             transferMode: str = "copy",
+             allowIntermediates: bool = False,
+             dryRun: bool = False) -> list[DatasetRef]:
+    """Copy (or link) datasets into ``outputRun``, optionally certifying them.
+
+    Parameters
+    ----------
+    outputRun : `str`, optional
+        RUN collection to copy the datasets into. If `None` the datasets are
+        left in the RUN they are already in.
+    calibCollection : `str`, optional
+        CALIBRATION collection to certify the results into.
+    beginDate, endDate : `str`, optional
+        ISO-8601 TAI bounds of the validity period. If ``beginDate`` is omitted,
+        the timespans are inherited from the source certification.
+    allowIntermediates : `bool`
+        Permit copying an `INTERMEDIATE_DATASET_TYPES` member, such as the bulky
+        ``rawISRCube`` ramps that a nirDark is combined from. Refused by default.
+
+    Raises
+    ------
+    ValueError
+        If an intermediate dataset type is requested without
+        ``allowIntermediates``.
+    """
+    if not allowIntermediates:
+        intermediates = sorted(set(datasetTypes) & INTERMEDIATE_DATASET_TYPES)
+        if intermediates:
+            raise ValueError(
+                f"{', '.join(intermediates)} is an intermediate product, not something "
+                "to promote into a shared collection; pass allowIntermediates to copy it "
+                "anyway")
+
+    refs = findDatasets(butler, datasetTypes, inputCollections, where=where)
+
+    # Resolve the source timespans before copying: the copies have new dataset
+    # IDs, and only the originals are certified anywhere.
+    sourceSpans: dict[DatasetRef, Timespan] | None = None
+    if calibCollection is not None:
+        if beginDate is None:
+            sourceSpans = sourceTimespans(butler, refs, inputCollections)
+        else:
+            sourceSpans = dict.fromkeys(refs, Timespan(isoTai(beginDate), isoTai(endDate)))
+
+    if dryRun:
+        for ref in refs:
+            where_ = ref.run if outputRun is None else outputRun
+            logger.info("would %s %s %s -> %s", "link" if outputRun is None else "copy",
+                        ref.datasetType.name, ref.dataId, where_)
+            if calibCollection is not None:
+                logger.info("    then certify into %s for %s", calibCollection, sourceSpans[ref])
+        return []
+
+    if outputRun is None:
+        copied = linkDatasets(butler, refs)
+    else:
+        copied = copyDatasets(butler, refs, outputRun, skipExisting=skipExisting,
+                              transferMode=transferMode)
+
+    if calibCollection is not None:
+        certifyDatasets(butler, calibCollection,
+                        {copied[ref]: span for ref, span in sourceSpans.items()})
+
+    return list(copied.values())

--- a/python/lsst/obs/pfs/isrTask.py
+++ b/python/lsst/obs/pfs/isrTask.py
@@ -1417,10 +1417,10 @@ class PfsIsrTask(ipIsr.IsrTask):
         return cube
 
     def getDarkRead(self, nirDark, readNum) -> np.ndarray:
-        """Get the dark read for the NIR ramp.
+        """Get one read of the dark cube, in ADU.
 
-        This wraps the fact that we switched from post-gain darks to
-        pre-gain darks.
+        The dark is stored in electrons, so the gain it was taken with is backed
+        out to match the raw ramp it is subtracted from.
 
         Parameters
         ----------
@@ -1432,16 +1432,14 @@ class PfsIsrTask(ipIsr.IsrTask):
         Returns
         -------
         `np.ndarray`
-            The dark read.
+            The dark read. Always a new array: `ImageCube.__getitem__` caches the
+            image it returns, so scaling it in place would corrupt the cube for
+            every later read of the same index.
         """
-
-        dark = nirDark[readNum].array
 
         # If gain was applied, back it out.
         gain = nirDark.metadata.get("GAIN", 1.0)
-        if gain != 1.0:
-            dark /= gain
-        return dark
+        return nirDark[readNum].array / gain
 
     def makeNirExposure(self, pfsRaw, nirDark=None, doReturnRawCube=False):
         """Construct a 2D image from the NIR ramp data.
@@ -1834,7 +1832,7 @@ class PfsIsrTask(ipIsr.IsrTask):
             chan0 = rawDiffIrp[rowLow:rowHigh, :]
 
             chanVec = np.nanmedian(chan0, axis=0, keepdims=True)
-            out[rowLow:rowHigh, :] = np.tile(chanVec, (h, 1))
+            out[rowLow:rowHigh, :] = chanVec  # broadcasts (1, w) down the channel's rows
         return out
 
     def getFinalDiffIrp(self, pfsRaw, rawDiffIrp, useFft=True) -> np.ndarray:

--- a/python/lsst/obs/pfs/nirSuperdark.py
+++ b/python/lsst/obs/pfs/nirSuperdark.py
@@ -1,0 +1,578 @@
+import datetime
+import logging
+import os
+import time
+from typing import NamedTuple
+
+import astropy.time
+import numpy as np
+
+import fitsio
+
+import lsst.daf.butler as dafButler
+from lsst.daf.butler import CollectionType, DatasetType, MissingCollectionError, Timespan
+from lsst.obs.pfs import imageCube
+
+from pfs.drp.stella.calibs import setCalibHeader
+
+logger = logging.getLogger(__name__)
+
+# Dimensions and storage class of the nirDark family of dataset types, matching
+# the registrations in `PrimeFocusSpectrograph.registerDatasetTypes`.
+DARK_DIMENSIONS = ("instrument", "arm", "spectrograph")
+DARK_STORAGE_CLASS = "ImageCube"
+
+
+def getExpInfo(exp):
+    """Get exposure start, read noise, and gain for an exposure.
+
+    Returns
+    -------
+    startTime: `datetime.datetime`
+    gain: `float`
+    readNoise: `float`
+    """
+    startTime: datetime.datetime = exp.getInfo().getVisitInfo().getDate().toPython()
+    det = exp.getDetector()
+    amp = det.getAmplifiers()[0]
+    gain = amp.getGain()
+    readNoise = amp.getReadNoise()
+    return startTime, gain, readNoise
+
+
+def getStartDate(butler: dafButler.Butler, dataId: dict, visit: int) -> datetime.datetime:
+    """The observation date of a visit, for use as a calibration's validity start."""
+    return getExpInfo(butler.get('postISRCCD', dataId, visit=visit))[0]
+
+
+def datasetTypeForIrp(irpN: int) -> str:
+    """Return the nirDark dataset type for a given IRP ratio.
+
+    The dark is subtracted from an exposure ramp read-by-read, so it is only
+    valid for exposures with the same per-read cadence. The IRP ratio changes
+    that cadence, so each ratio has its own product: the default (IRP1) writes
+    ``nirDark``, and other ratios write ``nirDark_irp<N>`` (e.g. ``nirDark_irp4``
+    for IRP4).
+    """
+    return "nirDark" if irpN == 1 else f"nirDark_irp{irpN}"
+
+
+def rampInfoFromCubes(cubes: dict, vlist: list[int]) -> tuple[dict, int]:
+    """Validate a set of open input ramps and extract their common IRP/timing cards.
+
+    The primary header of a rawISRCube carries the raw H4 metadata (see
+    `PfsIsrTask._makeExposure`).
+
+    Parameters
+    ----------
+    cubes : `dict` mapping visit to `fitsio.FITS`
+        The open input ramps.
+    vlist : list[int]
+        The visits to check, in order.
+
+    Returns
+    -------
+    rampInfo : `dict`
+        ``W_H4IRPN``, ``W_H4IRPO``, ``W_H4NRED``, ``W_H4FRMT``, common to all inputs.
+    nreads : `int`
+        The number of reads per ramp.
+
+    Raises
+    ------
+    ValueError
+        If the input ramps do not all share the same number of reads or the same
+        IRP ratio: they cannot be meaningfully combined.
+    """
+    rampInfo = None
+    nreads = None
+    for v in vlist:
+        hdr = cubes[v][0].read_header()
+        vReads = len(cubes[v]) - 1
+        # W_H4IRPO is the IRP pixel's position within each block of IRPN
+        # data pixels: it is 1-based and lies in 1..W_H4IRPN, so 1 (not 0)
+        # is the fallback when the card is absent.
+        vInfo = dict(W_H4IRPN=int(hdr.get("W_H4IRPN", 1)),
+                     W_H4IRPO=int(hdr.get("W_H4IRPO", 1)),
+                     W_H4NRED=int(hdr.get("W_H4NRED", vReads + 1)),
+                     W_H4FRMT=float(hdr.get("W_H4FRMT", 0.0)),
+                     )
+        # A rawISRCube holds the flux accumulated between consecutive reads, so
+        # it has one plane fewer than the ramp has reads: the first read is the
+        # reference every plane is measured against, not a plane of its own (see
+        # PfsIsrTask.makeUTRdeltas). A ramp that breaks this would give the dark a
+        # different plane count from the exposures it is subtracted from, which
+        # the read-by-read subtraction cannot detect.
+        if vReads != vInfo["W_H4NRED"] - 1:
+            raise ValueError(
+                f"input ramp {v} has {vReads} planes but W_H4NRED={vInfo['W_H4NRED']} "
+                f"reads; expected {vInfo['W_H4NRED'] - 1} planes."
+            )
+        if nreads is None:
+            nreads = vReads
+            rampInfo = vInfo
+        else:
+            if vReads != nreads:
+                raise ValueError(
+                    f"input ramp {v} has {vReads} reads; expected {nreads}. "
+                    "Dark ramps must have the same number of reads to combine."
+                )
+            if vInfo["W_H4IRPN"] != rampInfo["W_H4IRPN"]:
+                raise ValueError(
+                    f"input ramp {v} has IRP ratio {vInfo['W_H4IRPN']}; "
+                    f"expected {rampInfo['W_H4IRPN']}. Dark ramps must share an "
+                    "IRP ratio to combine (the ratio sets the read cadence)."
+                )
+    return rampInfo, nreads
+
+
+def getRampInfo(butler: dafButler.Butler,
+                dataId: dict[str, str],
+                vlist: list[int]) -> dict:
+    """Read the common IRP/timing cards of the input ramps, without their pixels.
+
+    Only the primary headers are read, so this is cheap enough to call before
+    committing to the combine.
+    """
+    cubes = dict()
+    try:
+        for v in vlist:
+            cubes[v] = fitsio.FITS(butler.getURI('rawISRCube', dataId, visit=v))
+        rampInfo, _ = rampInfoFromCubes(cubes, vlist)
+    finally:
+        for fits in cubes.values():
+            fits.close()
+    return rampInfo
+
+
+def collectionRoot(root: str) -> str:
+    """Normalize a collection base.
+
+    A trailing slash is stripped: butler collection names are opaque strings, so
+    ``u/me/calib/`` would otherwise yield ``u/me/calib//PIPE2D-1664/...`` and be
+    registered, silently, under that name.
+    """
+    root = root.rstrip("/")
+    if not root:
+        raise ValueError("collection base must not be empty")
+    return root
+
+
+def calibCollectionName(root: str, ticket: str, tag: str, product: str, iteration: str) -> str:
+    """The CALIBRATION collection the pipeline selects the calibration from.
+
+    ``{root}/{ticket}/{tag}/{product}.{iteration}``, following DMTN-222
+    (https://dmtn-222.lsst.io) as the pipeline-generated ``dark`` and ``bias`` do
+    (e.g. ``PFS/calib/pipe2d-1842/run28/dark.20260503a``). Note the absence of the
+    ``Gen`` suffix, which belongs to the generation chain.
+    """
+    return f"{collectionRoot(root)}/{ticket}/{tag}/{product}.{iteration}"
+
+
+def genCollectionName(root: str, ticket: str, tag: str, product: str, iteration: str) -> str:
+    """The CHAINED collection gathering everything one generation produced and used.
+
+    ``{root}/{ticket}/{tag}/{product}Gen.{iteration}``.
+    """
+    return f"{collectionRoot(root)}/{ticket}/{tag}/{product}Gen.{iteration}"
+
+
+def runName(genCollection: str, timestamp: str) -> str:
+    """The RUN the datasets are written to, within the generation chain.
+
+    Each attempt gets its own timestamped RUN, so a retry after a failed write
+    neither collides with nor overwrites the previous one.
+    """
+    return f"{genCollection}/{timestamp}"
+
+
+def defaultIteration() -> str:
+    """The default DMTN-222 rerun iteration: today's date plus ``a``."""
+    return datetime.date.today().strftime("%Y%m%d") + "a"
+
+
+def defaultTimestamp() -> str:
+    """The default RUN timestamp: the current UTC time, as ``YYYYMMDDTHHMMSSZ``."""
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def asTime(when) -> astropy.time.Time | None:
+    """Coerce a `datetime.datetime` (or `None`) to an `~astropy.time.Time`.
+
+    Naive datetimes are interpreted as UTC, matching the curated-calibration
+    behaviour in `makePfsCalibs`.
+    """
+    if when is None or isinstance(when, astropy.time.Time):
+        return when
+    return astropy.time.Time(when, format="datetime", scale="utc")
+
+
+def ensureCalibCollection(butler: dafButler.Butler, calibCollection: str) -> None:
+    """Make sure the CALIBRATION collection to certify into exists."""
+    if butler.registry.registerCollection(calibCollection, CollectionType.CALIBRATION):
+        logger.info("registered CALIBRATION collection %s", calibCollection)
+
+
+def ensureGenCollection(butler: dafButler.Butler, genCollection: str,
+                        members: list[str]) -> None:
+    """Make sure the generation CHAINED collection exists and holds ``members``.
+
+    Members already in the chain keep their position; new ones are prepended, so
+    the most recent RUN resolves first. This mirrors what ``pipetask -o`` builds
+    for the pipeline-generated calibrations.
+
+    Only this one chain is ever written. It is named for a single product,
+    ticket, tag and iteration, so it belongs to this generation alone; the shared
+    chains such as ``PFS/calib`` are maintained by hand and are never touched
+    here. Promoting a dark into one of those is a separate, deliberate step (see
+    `lsst.obs.pfs.datasetCopy`).
+    """
+    registry = butler.registry
+    if registry.registerCollection(genCollection, CollectionType.CHAINED):
+        logger.info("registered CHAINED collection %s", genCollection)
+    existing = list(registry.getCollectionChain(genCollection))
+    added = [member for member in members if member not in existing]
+    if added:
+        registry.setCollectionChain(genCollection, added + existing)
+        logger.info("chained %s into %s", ", ".join(added), genCollection)
+
+
+def ensureRunCollection(butler: dafButler.Butler, outputRun: str) -> None:
+    """Make sure the output collection exists and is a RUN, creating it if absent.
+
+    `Butler.put` cannot write to a CHAINED collection, so a CHAINED ``outputRun``
+    is rejected here rather than after the combine.
+
+    Raises
+    ------
+    ValueError
+        If ``outputRun`` exists but is not a RUN collection.
+    """
+    registry = butler.registry
+    try:
+        collectionType = registry.getCollectionType(outputRun)
+    except MissingCollectionError:
+        registry.registerCollection(outputRun, CollectionType.RUN)
+        logger.info("registered RUN collection %s", outputRun)
+    else:
+        if collectionType is not CollectionType.RUN:
+            raise ValueError(
+                f"output collection {outputRun!r} is of type {collectionType.name}; "
+                "a RUN collection is required to write the dark. Pass a RUN collection "
+                f"(e.g. {outputRun}/nirDark) as --output; it may then be chained into "
+                f"{outputRun!r} afterwards."
+            )
+
+
+def ensureDatasetType(butler: dafButler.Butler, datasetType: str) -> None:
+    """Register the given nirDark dataset type if the repository lacks it.
+
+    A newly-introduced ``nirDark_irp<N>`` will not exist in a repository created
+    before it was defined, so it is registered on use, as `makePfsCalibs` does
+    for its collections. Registration is idempotent.
+    """
+    registry = butler.registry
+    if registry.registerDatasetType(DatasetType(datasetType, DARK_DIMENSIONS,
+                                                DARK_STORAGE_CLASS,
+                                                universe=registry.dimensions,
+                                                isCalibration=True)):
+        logger.info("registered dataset type %s", datasetType)
+
+
+def ensureOutputs(butler: dafButler.Butler, outputRun: str, calibCollection: str,
+                  datasetType: str) -> None:
+    """Make sure the output collections and dataset type exist and are usable.
+
+    The combine takes hours, so everything that can make the final `Butler.put`
+    or `Registry.certify` fail is checked -- and fixed where we legitimately can
+    -- up front. Registration is idempotent, so it is harmless for the workers to
+    repeat what the wrapper already did.
+    """
+    ensureCalibCollection(butler, calibCollection)
+    ensureRunCollection(butler, outputRun)
+    ensureDatasetType(butler, datasetType)
+
+
+class Plan(NamedTuple):
+    """Everything the per-spectrograph combines must agree on, resolved once."""
+
+    datasetType: str
+    """``nirDark`` or ``nirDark_irp<N>``, from the inputs' IRP ratio."""
+    calibCollection: str
+    """The CALIBRATION collection to certify into."""
+    genCollection: str
+    """The CHAINED collection gathering this generation's run and its input."""
+    outputRun: str
+    """The timestamped RUN to put the dark into."""
+    startDate: datetime.datetime
+    """Start of the dark's validity period."""
+
+
+def planOutputs(butler: dafButler.Butler,
+                dataId: dict,
+                visits: list[int],
+                inputRun: str,
+                outputBase: str,
+                ticket: str,
+                tag: str,
+                iteration: str,
+                timestamp: str) -> Plan:
+    """Name and register the collections this combine will write, before it runs.
+
+    The dataset type follows from the inputs' IRP ratio, and names the product, so
+    the input headers -- but not their pixels -- have to be read first.
+    """
+    datasetType = datasetTypeForIrp(getRampInfo(butler, dataId, visits)["W_H4IRPN"])
+    calibCollection = calibCollectionName(outputBase, ticket, tag, datasetType, iteration)
+    genCollection = genCollectionName(outputBase, ticket, tag, datasetType, iteration)
+    outputRun = runName(genCollection, timestamp)
+    ensureOutputs(butler, outputRun, calibCollection, datasetType)
+    ensureGenCollection(butler, genCollection, [outputRun, inputRun])
+    return Plan(datasetType, calibCollection, genCollection, outputRun,
+                getStartDate(butler, dataId, visits[0]))
+
+
+def preflight(inputRun: str, outputBase: str,
+              dataId: dict,
+              visits: list[int],
+              ticket: str,
+              tag: str,
+              iteration: str,
+              timestamp: str,
+              repo_path: str = '/work/datastore') -> Plan:
+    """Resolve, once, everything the per-spectrograph combines must agree on.
+
+    Besides naming and registering the output collections, this reads the validity
+    start date from the first visit. Each detector latches its own timestamp a
+    second or two apart, so letting every spectrograph derive its own start date
+    would certify one logical dark set with several staggered validity periods --
+    and letting each derive its own RUN timestamp would scatter them across four
+    RUNs.
+    """
+    butler = makeButler(inputRun, None, repo_path)
+    return planOutputs(butler, dataId, visits, inputRun, outputBase, ticket, tag,
+                       iteration, timestamp)
+
+
+def saveNirDark(butler: dafButler.Butler,
+                dataId: dict[str, str],
+                run: str,
+                visits: list[int],
+                nirCube: np.ndarray,
+                start: datetime.datetime,
+                readNoise: float,
+                gain: float,
+                rampInfo: dict,
+                saveDir: str | None = None,
+                calibCollection: str | None = None):
+    """Write a combined NIR dark cube to the butler, and certify it as a calib.
+
+    The output dataset type (``nirDark`` or ``nirDark_irp<N>``) is selected from
+    the IRP ratio of the input ramps, and the IRP ratio and read-timing cards are
+    recorded in the header so the dark can be matched to exposures with the same
+    cadence.
+
+    Parameters
+    ----------
+    start : `datetime.datetime`
+        Start of the dark's validity period; normally the date of the first
+        input visit.
+    rampInfo : `dict`
+        IRP/timing cards common to the input ramps, as returned by
+        `makeMasterDark`: ``W_H4IRPN``, ``W_H4IRPO``, ``W_H4NRED``,
+        ``W_H4FRMT`` (per-read frame time).
+    saveDir : `str`, optional
+        If given, the cube is written here as a plain FITS file before it is put
+        to the butler, so that a butler failure does not throw away a combine
+        that takes hours. The file can be ingested afterwards.
+    calibCollection : `str`, optional
+        CALIBRATION collection to certify the dark into, so that ISR selects it
+        by observation date. If `None` the dark is only put into ``run``. The
+        validity period is open-ended: a later dark supersedes this one through
+        the calibration chain, not through an end date set here.
+    """
+
+    cam = f'n{dataId["spectrograph"]}'
+    metadata = dict(GAIN=gain,
+                    READNOISE=readNoise,
+                    CAM=cam,
+                    CALIBDATE=start.strftime('%Y-%m-%dT%H:%M:%S'),
+                    )
+    # Record the IRP ratio and read cadence so the dark can be matched to
+    # exposures read out the same way (the dark is subtracted read-by-read).
+    metadata.update(rampInfo)
+    setCalibHeader(metadata, 'dark', visitList=visits, outputId=dataId)
+    ic = imageCube.ImageCube.fromCube(nirCube, metadata)
+
+    datasetType = datasetTypeForIrp(rampInfo["W_H4IRPN"])
+
+    if saveDir is not None:
+        path = os.path.join(saveDir, f"{datasetType}-{cam}.fits")
+        t0 = time.time()
+        ic.writeFits(path)
+        logger.info("%s: wrote %s (%.1fs)", cam, path, time.time() - t0)
+
+    try:
+        with butler.transaction():
+            ref = butler.put(ic, datasetType, dataId, run=run)
+            if calibCollection is not None:
+                timespan = Timespan(asTime(start), None)
+                butler.registry.certify(calibCollection, [ref], timespan)
+                logger.info("%s: certified %s into %s for %s",
+                            cam, datasetType, calibCollection, timespan)
+    except Exception:
+        if saveDir is not None:
+            logger.error("%s: butler.put of %s failed; the combined dark is safe in %s",
+                         cam, datasetType, path)
+        raise
+
+
+def makeMasterDark(butler: dafButler.Butler,
+                   dataId: dict[str, str],
+                   vlist: list[int]):
+    """Construct a single dark cube from a set of already processed rawISRCubes.
+
+    Parameters
+    ----------
+    butler : `dafButler.Butler`
+       Configured to .get our rawISRCubes.
+    dataId : `dict`
+       Everything but the visit
+    vlist : list[int]
+       The visits to merge
+
+    Returns
+    -------
+    nirDark : `np.ndarray`
+       The merged master dark, shaped ``(nreads, height, width)``.
+    offsets : `list`
+       The offsets, per-read, between the individual input darks.
+    rampInfo : `dict`
+       IRP/timing cards common to all inputs (``W_H4IRPN``, ``W_H4IRPO``,
+       ``W_H4NRED``, ``W_H4FRMT``), for the output header.
+
+    Raises
+    ------
+    ValueError
+        If the input ramps do not all share the same number of reads or the same
+        IRP ratio: they cannot be meaningfully combined.
+    """
+
+    # Open all input cubes. We then step through them one read at a time,
+    # combining them into a single new super dark.
+    #
+    # We use fitsio directly rather than astropy.io.fits or the ImageCube
+    # wrapper: astropy.io.fits internally caches the images, which is
+    # catastrophic here. You can flush the cache or bypass it, but it is cleaner
+    # just to access the data directly.
+    cubes = dict()
+    try:
+        for v in vlist:
+            cubeLoc = butler.getURI('rawISRCube', dataId, visit=v)
+            cubes[v] = fitsio.FITS(cubeLoc)
+
+        # Validate that the inputs are compatible, and gather the IRP/timing
+        # cards to stamp on the output.
+        rampInfo, nreads = rampInfoFromCubes(cubes, vlist)
+
+        ndarks = len(cubes)
+        height, width = cubes[vlist[0]]['IMAGE_1'].read().shape
+
+        oneRead = np.zeros(shape=(ndarks, height, width), dtype='f4')
+        newCube = np.zeros(shape=(nreads, height, width), dtype='f4')
+        offsets = []
+        cam = f'n{dataId["spectrograph"]}'
+        visits = list(cubes.keys())
+        logger.info("%s: combining %d dark ramps of %d reads (%dx%d)",
+                    cam, ndarks, nreads, height, width)
+        ioTime = procTime = 0.0
+        for r_i in range(nreads):
+            t0 = time.time()
+            for v_i, v in enumerate(visits):
+                oneRead[v_i, :, :] = cubes[v][f'IMAGE_{r_i+1}'].read()
+            t1 = time.time()
+
+            # Correct any offsets between ramps for this single read. Make sure
+            # not to take out the common increase in flux.
+            readMeds = np.median(oneRead, axis=(1, 2))
+            readMeds -= np.median(readMeds)
+            offsets.append(readMeds)
+            oneRead -= readMeds[:, None, None]
+
+            # Finish this read
+            newCube[r_i] = np.median(oneRead, axis=0)
+            t2 = time.time()
+
+            ioTime += t1 - t0
+            procTime += t2 - t1
+            # Report progress and the single worst ramp offset, so an outlier
+            # dark is visible without dumping the whole per-ramp offset list.
+            worst = int(np.argmax(np.abs(readMeds)))
+            logger.info("%s read %d/%d: max|offset|=%.1f (visit %d)  io=%.1fs proc=%.1fs",
+                        cam, r_i + 1, nreads, abs(readMeds[worst]), visits[worst],
+                        t1 - t0, t2 - t1)
+
+        logger.info("%s: combined %d reads in %.1fs (read=%.1fs combine=%.1fs)",
+                    cam, nreads, ioTime + procTime, ioTime, procTime)
+    finally:
+        for fits in cubes.values():
+            fits.close()
+
+    return newCube, offsets, rampInfo
+
+
+def makeButler(inputRun: str, outputRun: str | None,
+               repo_path: str = '/work/datastore') -> dafButler.Butler:
+    """Open a writeable butler reading from ``inputRun`` and writing to ``outputRun``.
+
+    ``outputRun`` may be `None` when the output collection is not yet named, as
+    when preflighting.
+    """
+    collections = [inputRun, 'PFS/defaults']
+    if outputRun is not None:
+        collections.insert(0, outputRun)
+    return dafButler.Butler(repo_path,
+                            collections=collections,
+                            run=outputRun,
+                            writeable=True)
+
+
+def processMasterDark(inputRun: str, outputRun: str,
+                      dataId: dict,
+                      visits: list[int],
+                      startDate=None,
+                      repo_path='/work/datastore',
+                      saveDir=None,
+                      calibCollection=None):
+    """Combine a spectrograph's dark ramps, then put and certify the result.
+
+    ``startDate`` defaults to the observation date of the first input visit, and
+    is both the ``CALIBDATE`` header card and the start of the certified,
+    open-ended validity period.
+    """
+
+    mdButler = makeButler(inputRun, outputRun, repo_path)
+
+    # Register the outputs before the combine, so that hours of work are not
+    # thrown away by a butler problem at the put. The wrapper has already done
+    # this for every spectrograph, making these no-ops; repeating it here keeps a
+    # direct caller honest.
+    if calibCollection is not None:
+        ensureCalibCollection(mdButler, calibCollection)
+    ensureRunCollection(mdButler, outputRun)
+    ensureDatasetType(mdButler, datasetTypeForIrp(getRampInfo(mdButler, dataId,
+                                                              visits)["W_H4IRPN"]))
+
+    exp = mdButler.get('postISRCCD', dataId, visit=visits[0])
+    expStartTime, gain, readNoise = getExpInfo(exp)
+    if startDate is None:
+        startDate = expStartTime
+    t0 = time.time()
+    darkCube, offsets, rampInfo = makeMasterDark(mdButler, dataId, visits)
+    t1 = time.time()
+    saveNirDark(mdButler, dataId, outputRun, visits,
+                darkCube, start=startDate,
+                readNoise=readNoise, gain=gain, rampInfo=rampInfo,
+                saveDir=saveDir, calibCollection=calibCollection)
+    t2 = time.time()
+    del darkCube
+    logger.info("n%s: make=%0.1fs save=%0.1fs", dataId["spectrograph"], t1 - t0, t2 - t1)

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -1,0 +1,59 @@
+"""Shared helpers for the obs_pfs tests.
+
+Some tests need packages that ``obs_pfs`` cannot declare as dependencies:
+
+- ``drp_stella`` declares ``setupRequired(obs_pfs)``, so depending on it back
+  would be circular. ``lsst.obs.pfs.isrTask`` and ``lsst.obs.pfs.nirSuperdark``
+  nevertheless import from it, so tests touching them can only be skipped.
+- ``drp_pfs_data`` is a bulky data package that a self-contained build does not
+  set up.
+
+Tests requiring either are skipped rather than failed, so ``scons`` passes on a
+plain ``setup -r .`` checkout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+
+from lsst.utils import getPackageDir
+
+OBS_PFS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def loadScript(name):
+    """Import one of the ``bin.src`` scripts as a module."""
+    path = os.path.join(OBS_PFS_DIR, "bin.src", f"{name}.py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def hasPackage(name: str) -> bool:
+    """Is the named EUPS product set up?"""
+    try:
+        getPackageDir(name)
+    except LookupError:
+        return False
+    return True
+
+
+def hasModule(name: str) -> bool:
+    """Is the named Python module importable?"""
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+HAS_DRP_STELLA = hasModule("pfs.drp.stella")
+HAS_DRP_PFS_DATA = hasPackage("drp_pfs_data")
+
+requireDrpStella = unittest.skipUnless(
+    HAS_DRP_STELLA,
+    "drp_stella is not set up (it depends on obs_pfs, so obs_pfs cannot require it)")
+requireDrpPfsData = unittest.skipUnless(
+    HAS_DRP_PFS_DATA, "drp_pfs_data is not set up")

--- a/tests/test_combineNirDark.py
+++ b/tests/test_combineNirDark.py
@@ -1,0 +1,278 @@
+"""Tests for the ``combineNirDark`` command-line wrapper.
+
+The wrapper is a thin driver over ``lsst.obs.pfs.nirSuperdark.processMasterDark``
+that expands visit ranges and reduces the requested spectrographs in parallel.
+These tests confirm argument marshalling, visit-range parsing, the parallel
+fan-out, and per-spectrograph error aggregation.
+"""
+
+import datetime
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+import lsst.utils.tests
+
+from testUtils import HAS_DRP_STELLA, loadScript, requireDrpStella
+
+if HAS_DRP_STELLA:
+    # nirSuperdark imports pfs.drp.stella.calibs.setCalibHeader.
+    from lsst.obs.pfs import nirSuperdark
+
+
+def markerWorker(inputRun, outputRun, dataId, visits, startDate=None, repo_path=None,
+                 saveDir=None, calibCollection=None):
+    """Stand-in for ``processMasterDark`` that records a run as a file.
+
+    Module-level (hence picklable) so it can be dispatched to worker processes
+    in the parallel-execution test.
+    """
+    with open(os.path.join(repo_path, f"n{dataId['spectrograph']}.done"), "w") as fd:
+        fd.write(repr((inputRun, outputRun, sorted(visits), startDate)))
+
+
+VISIT_START = datetime.datetime(2026, 6, 25, 5, 23, 17)
+TIMESTAMP = "20260709T123456Z"
+
+
+def fakePreflight(inputRun, outputBase, dataId, visits, ticket, tag, iteration,
+                  timestamp, repo_path=None):
+    """Stand-in for ``preflight``: no butler to name collections against here."""
+    gen = nirSuperdark.genCollectionName(outputBase, ticket, tag, "nirDark", iteration)
+    return nirSuperdark.Plan(
+        datasetType="nirDark",
+        calibCollection=nirSuperdark.calibCollectionName(outputBase, ticket, tag,
+                                                         "nirDark", iteration),
+        genCollection=gen,
+        outputRun=nirSuperdark.runName(gen, timestamp),
+        startDate=VISIT_START,
+    )
+
+
+@requireDrpStella
+class CombineNirDarkTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        self.script = loadScript("combineNirDark")
+        self.calls = []
+        self.origArgv = sys.argv
+        self.origProcess = nirSuperdark.processMasterDark
+        self.origPreflight = nirSuperdark.preflight
+
+        def recorder(*args, **kwargs):
+            self.calls.append((args, kwargs))
+
+        nirSuperdark.processMasterDark = recorder
+        nirSuperdark.preflight = fakePreflight
+
+    def tearDown(self):
+        nirSuperdark.processMasterDark = self.origProcess
+        nirSuperdark.preflight = self.origPreflight
+        sys.argv = self.origArgv
+
+    def run_main(self, argv):
+        # Force inline execution so the monkeypatched recorder (a closure, not
+        # picklable) runs in this process and records the calls.
+        extra = ["--processes", "1"]
+        if "--ticket" not in argv:
+            extra += ["--ticket", "PIPE2D-1664", "--tag", "tag",
+                      "--iteration", "20260709a"]
+        if "--run-timestamp" not in argv:
+            extra += ["--run-timestamp", TIMESTAMP]
+        sys.argv = ["combineNirDark"] + argv + extra
+        self.script.main()
+
+    def testArgsMarshalled(self):
+        self.run_main([
+            "/some/repo",
+            "--input", "u/me/in",
+            "--output", "u/me/out",
+            "--spectrograph", "1",
+            "--visits", "10", "20", "30",
+        ])
+        self.assertEqual(len(self.calls), 1)
+        args, kwargs = self.calls[0]
+        inputRun, outputRun, dataId, visits = args
+        self.assertEqual(inputRun, "u/me/in")
+        # Names composed under the --output base: the certified collection drops
+        # the Gen suffix, and the datasets land in a timestamped run beneath it.
+        base = "u/me/out/PIPE2D-1664/tag"
+        self.assertEqual(outputRun, f"{base}/nirDarkGen.20260709a/{TIMESTAMP}")
+        self.assertEqual(kwargs["calibCollection"], f"{base}/nirDark.20260709a")
+        self.assertEqual(dataId, dict(instrument="PFS", arm="n", spectrograph=1))
+        self.assertEqual(visits, [10, 20, 30])
+        self.assertEqual(kwargs["repo_path"], "/some/repo")
+        # Resolved from the first visit by the parent, not left for the worker.
+        self.assertEqual(kwargs["startDate"], VISIT_START)
+
+    def testAllSpectrographsShareOneStartDate(self):
+        """One dark set gets one validity start, not one per detector's timestamp."""
+        self.run_main(["/repo", "--input", "in", "--output", "out", "--visits", "7"])
+        self.assertEqual(len(self.calls), 4)
+        startDates = {kwargs["startDate"] for _, kwargs in self.calls}
+        self.assertEqual(startDates, {VISIT_START})
+
+    def testStartDateParsedToDatetime(self):
+        """The start date reaches saveNirDark as a datetime, not a string."""
+        self.run_main([
+            "/repo", "--input", "in", "--output", "out", "--spectrograph", "1",
+            "--visits", "7", "--start-date", "2026-01-02T03:04:05",
+        ])
+        self.assertEqual(self.calls[0][1]["startDate"],
+                         datetime.datetime(2026, 1, 2, 3, 4, 5))
+
+    def testIterationDefaultsToToday(self):
+        self.run_main([
+            "/repo", "--input", "in", "--output", "out", "--spectrograph", "1",
+            "--visits", "7", "--ticket", "PIPE2D-1664", "--tag", "tag",
+        ])
+        expected = nirSuperdark.defaultIteration()
+        self.assertTrue(self.calls[0][1]["calibCollection"].endswith(f"nirDark.{expected}"))
+
+    def testRunTimestampDefaultsToNow(self):
+        self.run_main([
+            "/repo", "--input", "in", "--output", "out", "--spectrograph", "1",
+            "--visits", "7", "--run-timestamp", "20991231T235959Z",
+        ])
+        self.assertTrue(self.calls[0][0][1].endswith("/20991231T235959Z"))
+
+    def testAllSpectrographsShareOneRun(self):
+        """A rerun gets a fresh RUN, but one run holds the whole set."""
+        self.run_main(["/repo", "--input", "in", "--output", "out", "--visits", "7"])
+        outputRuns = {args[1] for args, _ in self.calls}
+        self.assertEqual(len(outputRuns), 1)
+        self.assertTrue(outputRuns.pop().endswith(f"/{TIMESTAMP}"))
+
+    def testDefaultsToAllSpectrographs(self):
+        self.run_main([
+            "/repo", "--input", "in", "--output", "out", "--visits", "7",
+        ])
+        self.assertEqual(len(self.calls), 4)
+        spectrographs = [args[2]["spectrograph"] for args, _ in self.calls]
+        self.assertEqual(spectrographs, [1, 2, 3, 4])
+        for args, _ in self.calls:
+            _, _, dataId, visits = args
+            self.assertEqual(dataId["arm"], "n")
+            self.assertEqual(visits, [7])
+
+    def testStartDateAndSpectrographSubset(self):
+        self.run_main([
+            "/repo",
+            "--input", "in", "--output", "out",
+            "--spectrograph", "3", "4",
+            "--visits", "7",
+            "--start-date", "2026-01-02T03:04:05",
+        ])
+        self.assertEqual([args[2]["spectrograph"] for args, _ in self.calls], [3, 4])
+        for _, kwargs in self.calls:
+            self.assertEqual(kwargs["startDate"], datetime.datetime(2026, 1, 2, 3, 4, 5))
+
+    def testSaveDirDefaultsToCwd(self):
+        self.run_main(["/repo", "--input", "in", "--output", "out",
+                       "--spectrograph", "1", "--visits", "7"])
+        self.assertEqual(self.calls[0][1]["saveDir"], ".")
+
+    def testSaveDirCreated(self):
+        root = tempfile.mkdtemp(prefix="combineNirDark-save-")
+        saveDir = os.path.join(root, "nested", "out")
+        try:
+            self.run_main(["/repo", "--input", "in", "--output", "out",
+                           "--spectrograph", "1", "--visits", "7",
+                           "--save-dir", saveDir])
+            self.assertTrue(os.path.isdir(saveDir))
+            self.assertEqual(self.calls[0][1]["saveDir"], saveDir)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def testPreflightFailureAbortsBeforeAnyWork(self):
+        """A bad output collection or dataset type must not cost a combine."""
+        def boom(*args, **kwargs):
+            raise ValueError("output collection 'out' is of type CHAINED")
+
+        nirSuperdark.preflight = boom
+        with self.assertRaises(ValueError):
+            self.script.reduceSpectrographs("/repo", "in", "out", [1, 2, 3, 4], [7],
+                                            "PIPE2D-1664", "tag", "20260709a", TIMESTAMP,
+                                            processes=1)
+        self.assertEqual(self.calls, [])
+
+    def testVisitsRequired(self):
+        with self.assertRaises(SystemExit):
+            self.run_main(["/repo", "--input", "in", "--output", "out",
+                           "--spectrograph", "1"])
+
+    def testVisitRangesExpanded(self):
+        self.run_main([
+            "/repo", "--input", "in", "--output", "out", "--spectrograph", "1",
+            "--visits", "144784..144788", "200", "300..306:2",
+        ])
+        _, _, _, visits = self.calls[0][0]
+        self.assertEqual(
+            visits,
+            [144784, 144785, 144786, 144787, 144788, 200, 300, 302, 304, 306])
+
+    def testErrorsAggregated(self):
+        """One spectrograph failing does not abandon the others."""
+        def failing(inputRun, outputRun, dataId, visits, **kwargs):
+            self.calls.append(dataId["spectrograph"])
+            if dataId["spectrograph"] == 2:
+                raise ValueError("boom")
+
+        nirSuperdark.processMasterDark = failing
+        with self.assertRaises(RuntimeError) as cm:
+            self.script.reduceSpectrographs(
+                "/repo", "in", "out", [1, 2, 3], [7],
+                "PIPE2D-1664", "tag", "20260709a", TIMESTAMP, processes=1)
+        self.assertIn("n2", str(cm.exception))
+        self.assertEqual(sorted(self.calls), [1, 2, 3])
+
+    def testParallelExecutionRunsAll(self):
+        """The parallel path dispatches every spectrograph to a worker process."""
+        nirSuperdark.processMasterDark = markerWorker
+        root = tempfile.mkdtemp(prefix="combineNirDark-par-")
+        try:
+            self.script.reduceSpectrographs(
+                root, "in", "out", [1, 2, 3, 4], [7],
+                "PIPE2D-1664", "tag", "20260709a", TIMESTAMP, processes=2)
+            self.assertEqual(sorted(os.listdir(root)),
+                             ["n1.done", "n2.done", "n3.done", "n4.done"])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+@requireDrpStella
+class ParseVisitsTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        self.script = loadScript("combineNirDark")
+
+    def testPlainInts(self):
+        self.assertEqual(self.script.parseVisits(["10", "20"]), [10, 20])
+
+    def testInclusiveRange(self):
+        self.assertEqual(self.script.parseVisitRange("5..8"), [5, 6, 7, 8])
+
+    def testRangeWithStep(self):
+        self.assertEqual(self.script.parseVisitRange("1..10:3"), [1, 4, 7, 10])
+
+    def testMixed(self):
+        self.assertEqual(
+            self.script.parseVisits(["1", "3..5", "9"]), [1, 3, 4, 5, 9])
+
+    def testBadRangesRaise(self):
+        for bad in ("8..5", "1..10:0", "1..2..3", "1..x"):
+            with self.assertRaises(ValueError):
+                self.script.parseVisitRange(bad)
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    setup_module(sys.modules["__main__"])
+    unittest.main(failfast=True)

--- a/tests/test_datasetCopy.py
+++ b/tests/test_datasetCopy.py
@@ -1,0 +1,302 @@
+"""Tests for copying/linking datasets between collections (``datasetCopy``).
+
+A dataset's RUN is immutable, so promoting a calibration into a shared collection
+means reading it and writing it out again. These tests cover that copy, the
+no-copy alternative, inheriting the source certification's validity period, and
+the guards around resuming an interrupted copy.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+import astropy.time
+import numpy as np
+
+import lsst.utils.tests
+from lsst.daf.butler import CollectionType, Timespan
+from lsst.daf.butler._exceptions import MissingDatasetTypeError
+from lsst.daf.butler.registry import ConflictingDefinitionError
+
+from lsst.obs.pfs import datasetCopy
+from lsst.obs.pfs.imageCube import ImageCube
+
+from testUtils import loadScript
+
+BEGIN = astropy.time.Time("2026-07-08T12:00:00", format="isot", scale="tai")
+
+
+class DatasetCopyTestCase(lsst.utils.tests.TestCase):
+    """Round-trip through a throwaway Gen3 butler."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="datasetCopy-repo-")
+        self.butler = loadScript("makePfsTestRepo").makePfsTestRepo(
+            os.path.join(self.root, "repo"))
+        self.srcRun = "u/test/src/put"
+        self.butler.registry.registerRun(self.srcRun)
+        self.dataIds = [dict(instrument="PFS", arm="n", spectrograph=s) for s in (1, 2)]
+        self.data = {}
+        self.srcRefs = []
+        for i, dataId in enumerate(self.dataIds):
+            data = np.full((2, 3, 3), i + 1, dtype="f4")
+            self.data[dataId["spectrograph"]] = data
+            cube = ImageCube.fromCube(data, dict(W_H4IRPN=1))
+            self.srcRefs.append(self.butler.put(cube, "nirDark", dataId, run=self.srcRun))
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def certifySource(self, calib="u/test/src/nirDarkGen.20260708a"):
+        self.butler.registry.registerCollection(calib, CollectionType.CALIBRATION)
+        self.butler.registry.certify(calib, self.srcRefs, Timespan(BEGIN, None))
+        return calib
+
+    def testCopyMakesIndependentDatasets(self):
+        outputRun = "PFS/calib/test/nirDarkGen.20260708a/put"
+        newRefs = datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun],
+                                       outputRun=outputRun)
+        self.assertEqual(len(newRefs), 2)
+        for ref in newRefs:
+            self.assertEqual(ref.run, outputRun)
+        # New dataset IDs: these are copies, not the originals re-pointed.
+        self.assertFalse({r.id for r in newRefs} & {r.id for r in self.srcRefs})
+        # And the pixels survived the round trip.
+        for dataId in self.dataIds:
+            cube = self.butler.get("nirDark", dataId, collections=outputRun)
+            self.assertFloatsAlmostEqual(cube.getImageCube(),
+                                         self.data[dataId["spectrograph"]])
+
+    def testCopySurvivesSourceRemoval(self):
+        """The point of copying: the destination must not depend on the source."""
+        outputRun = "PFS/calib/test/independent/put"
+        datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun], outputRun=outputRun)
+        self.butler.removeRuns([self.srcRun])
+        for dataId in self.dataIds:
+            cube = self.butler.get("nirDark", dataId, collections=outputRun)
+            self.assertFloatsAlmostEqual(cube.getImageCube(),
+                                         self.data[dataId["spectrograph"]])
+
+    def testTimespanInheritedFromSourceCertification(self):
+        calib = self.certifySource()
+        outputRun = "PFS/calib/test/inherit/put"
+        destCalib = "PFS/calib/test/inherit"
+        datasetCopy.transfer(self.butler, ["nirDark"], [calib], outputRun=outputRun,
+                             calibCollection=destCalib)
+        registry = self.butler.registry
+        self.assertEqual(registry.getCollectionType(destCalib), CollectionType.CALIBRATION)
+        # Valid after the inherited begin date, and open-ended.
+        far = astropy.time.Time("2099-01-01T00:00:00", format="isot", scale="tai")
+        for dataId in self.dataIds:
+            self.assertIsNotNone(registry.findDataset("nirDark", dataId, collections=destCalib,
+                                                      timespan=Timespan(far, far)))
+        # Not valid before it was taken: the inherited begin date was respected.
+        before = astropy.time.Time("2020-01-01T00:00:00", format="isot", scale="tai")
+        for dataId in self.dataIds:
+            self.assertIsNone(registry.findDataset("nirDark", dataId, collections=destCalib,
+                                                   timespan=Timespan(before, before)))
+
+    def testExplicitBeginDateOverridesSource(self):
+        calib = self.certifySource()
+        destCalib = "PFS/calib/test/explicit"
+        datasetCopy.transfer(self.butler, ["nirDark"], [calib],
+                             outputRun="PFS/calib/test/explicit/put",
+                             calibCollection=destCalib, beginDate="2030-01-01T00:00:00")
+        registry = self.butler.registry
+        # 2027 falls after the source begin date but before the explicit one.
+        mid = astropy.time.Time("2027-01-01T00:00:00", format="isot", scale="tai")
+        self.assertIsNone(registry.findDataset("nirDark", self.dataIds[0],
+                                               collections=destCalib,
+                                               timespan=Timespan(mid, mid)))
+
+    def testUncertifiedSourceCannotInheritTimespan(self):
+        """Inheriting a validity period from a plain RUN is not possible."""
+        with self.assertRaises(RuntimeError) as cm:
+            datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun],
+                                 outputRun="PFS/calib/test/nospan/put",
+                                 calibCollection="PFS/calib/test/nospan")
+        self.assertIn("not certified", str(cm.exception))
+
+    def testNoCopyLeavesDatasetsInSourceRun(self):
+        calib = self.certifySource()
+        destCalib = "PFS/calib/test/linked"
+        newRefs = datasetCopy.transfer(self.butler, ["nirDark"], [calib],
+                                       outputRun=None, calibCollection=destCalib)
+        for ref in newRefs:
+            self.assertEqual(ref.run, self.srcRun)
+        self.assertEqual({r.id for r in newRefs}, {r.id for r in self.srcRefs})
+
+    def testRepeatedCopyConflictsUnlessSkipping(self):
+        outputRun = "PFS/calib/test/twice/put"
+        datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun], outputRun=outputRun)
+        with self.assertRaises(ConflictingDefinitionError):
+            datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun], outputRun=outputRun)
+        # Resuming an interrupted copy is allowed, and maps to the existing datasets.
+        newRefs = datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun],
+                                       outputRun=outputRun, skipExisting=True)
+        self.assertEqual(len(newRefs), 2)
+        for ref in newRefs:
+            self.assertEqual(ref.run, outputRun)
+
+    def testDryRunWritesNothing(self):
+        outputRun = "PFS/calib/test/dry/put"
+        self.assertEqual(
+            datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun],
+                                 outputRun=outputRun, dryRun=True),
+            [])
+        with self.assertRaises(Exception):
+            self.butler.registry.getCollectionType(outputRun)
+
+    def testMissingDatasetsRaise(self):
+        with self.assertRaises(RuntimeError) as cm:
+            datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun],
+                                 outputRun="PFS/calib/test/none/put",
+                                 where="instrument='PFS' AND spectrograph = 3")
+        self.assertIn("no datasets", str(cm.exception))
+
+    def testWhereRestrictsCopy(self):
+        outputRun = "PFS/calib/test/where/put"
+        newRefs = datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun],
+                                       outputRun=outputRun,
+                                       where="instrument='PFS' AND spectrograph = 2")
+        self.assertEqual(len(newRefs), 1)
+        self.assertEqual(newRefs[0].dataId["spectrograph"], 2)
+
+    def testCopiedPixelsSurviveStorageClassRoundTrip(self):
+        """Regression: copying must not go through ImageCube.get/put.
+
+        A fetched ImageCube is lazily backed by its file and holds no images, so
+        writeFits would persist a header with no image HDUs -- losing every read
+        without raising. Copying the artifact sidesteps the storage class.
+        """
+        outputRun = "PFS/calib/test/pixels/put"
+        datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun], outputRun=outputRun)
+        for dataId in self.dataIds:
+            cube = self.butler.get("nirDark", dataId, collections=outputRun)
+            self.assertEqual(cube.nreads, 2)
+            self.assertFloatsAlmostEqual(cube.getImageCube(),
+                                         self.data[dataId["spectrograph"]])
+            self.assertEqual(cube.metadata.get("W_H4IRPN"), 1)
+
+    def testDisassembledCompositeRejected(self):
+        """A dataset with no single artifact cannot be copied silently."""
+        ref = self.srcRefs[0]
+
+        class FakeUris:
+            primaryURI = None
+            componentURIs = {"image": "file:///nowhere.fits"}
+
+        original = self.butler.getURIs
+        self.butler.getURIs = lambda _ref: FakeUris()
+        try:
+            with self.assertRaises(NotImplementedError):
+                datasetCopy.artifactUri(self.butler, ref)
+        finally:
+            self.butler.getURIs = original
+
+    def testScratchCubesRefusedByDefault(self):
+        """The bulky rawISRCube intermediates must not be promoted by accident."""
+        with self.assertRaises(ValueError) as cm:
+            datasetCopy.transfer(self.butler, ["rawISRCube"], [self.srcRun],
+                                 outputRun="PFS/calib/test/scratch/put")
+        self.assertIn("intermediate product", str(cm.exception))
+        # Nothing was even queried, let alone written.
+        with self.assertRaises(Exception):
+            self.butler.registry.getCollectionType("PFS/calib/test/scratch/put")
+
+    def testScratchCubesCopyableWhenAsked(self):
+        """The refusal is a guard, not a prohibition: allowIntermediates lifts it.
+
+        The throwaway repo has no ``rawISRCube`` dataset type (it needs visit
+        dimensions this repo lacks), so the call still fails -- but on the missing
+        type, having got past the intermediate guard.
+        """
+        with self.assertRaises(MissingDatasetTypeError):
+            datasetCopy.transfer(self.butler, ["rawISRCube"], [self.srcRun],
+                                 outputRun="u/test/scratchCopy/put",
+                                 allowIntermediates=True)
+
+    def testIntermediateRefusedEvenAlongsideWantedType(self):
+        """Naming a good type does not smuggle an intermediate along with it."""
+        with self.assertRaises(ValueError) as cm:
+            datasetCopy.transfer(self.butler, ["nirDark", "rawISRCube"], [self.srcRun],
+                                 outputRun="PFS/calib/test/mixed/put")
+        self.assertIn("rawISRCube", str(cm.exception))
+
+    def testChainedInputCopiesOnlyNamedDatasetType(self):
+        """A chain holding other products must not leak them into the copy.
+
+        This is what keeps a scratchCubes collection out of a promotion: only the
+        dataset types named on the command line are ever queried.
+        """
+        otherRun = "u/test/other"
+        self.butler.registry.registerRun(otherRun)
+        self.butler.put(ImageCube.fromCube(np.zeros((2, 3, 3), dtype="f4"), dict(W_H4IRPN=4)),
+                        "nirDark_irp4", self.dataIds[0], run=otherRun)
+        chain = "u/test/everything"
+        self.butler.registry.registerCollection(chain, CollectionType.CHAINED)
+        self.butler.registry.setCollectionChain(chain, [self.srcRun, otherRun])
+
+        outputRun = "PFS/calib/test/fromchain/put"
+        newRefs = datasetCopy.transfer(self.butler, ["nirDark"], [chain], outputRun=outputRun)
+        self.assertEqual({ref.datasetType.name for ref in newRefs}, {"nirDark"})
+        self.assertEqual(
+            self.butler.query_datasets("nirDark_irp4", collections=[outputRun],
+                                       explain=False, limit=1),
+            [])
+
+    def testOutputRunMustBeRun(self):
+        chain = "u/test/chain"
+        self.butler.registry.registerCollection(chain, CollectionType.CHAINED)
+        with self.assertRaises(ValueError) as cm:
+            datasetCopy.transfer(self.butler, ["nirDark"], [self.srcRun], outputRun=chain)
+        self.assertIn("CHAINED", str(cm.exception))
+
+
+class CopyDatasetsScriptTestCase(lsst.utils.tests.TestCase):
+    """Argument guards in the ``copyDatasets`` wrapper."""
+
+    def setUp(self):
+        self.script = loadScript("copyDatasets")
+        self.origArgv = sys.argv
+
+    def tearDown(self):
+        sys.argv = self.origArgv
+
+    def run_main(self, argv):
+        sys.argv = ["copyDatasets"] + argv
+        self.script.main()
+
+    def testOutputRunRequired(self):
+        with self.assertRaises(SystemExit):
+            self.run_main(["/repo", "--input", "in", "--dataset-type", "nirDark"])
+
+    def testNoCopyRejectsOutputRun(self):
+        with self.assertRaises(SystemExit):
+            self.run_main(["/repo", "--input", "in", "--dataset-type", "nirDark",
+                           "--no-copy", "--certify", "calib", "--output-run", "run"])
+
+    def testNoCopyRequiresCertify(self):
+        with self.assertRaises(SystemExit):
+            self.run_main(["/repo", "--input", "in", "--dataset-type", "nirDark",
+                           "--no-copy"])
+
+    def testDatasetTypeHasNoDefault(self):
+        """Nothing is copied unless a dataset type is named: no wildcard, no default."""
+        with self.assertRaises(SystemExit):
+            self.run_main(["/repo", "--input", "in", "--output-run", "out"])
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    setup_module(sys.modules["__main__"])
+    unittest.main(failfast=True)

--- a/tests/test_isrDarkCube.py
+++ b/tests/test_isrDarkCube.py
@@ -1,0 +1,104 @@
+"""Tests for how ``PfsIsrTask`` reads the NIR dark cube back out.
+
+The dark is stored in electrons and subtracted from the raw ramp in ADU, so both
+accessors divide by the gain the dark was taken with. Neither may scale the
+`ImageCube`'s cached images in place.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+
+import lsst.utils.tests
+
+from lsst.obs.pfs.imageCube import ImageCube
+
+from testUtils import HAS_DRP_STELLA, requireDrpStella
+
+if HAS_DRP_STELLA:
+    # isrTask imports pfs.drp.stella.crosstalk.
+    from lsst.obs.pfs.isrTask import PfsIsrTask
+
+GAIN = 2.0
+LEVEL = 10.0
+NREADS = 3
+
+
+@requireDrpStella
+class DarkCubeAccessTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="isrDarkCube-")
+        self.path = os.path.join(self.root, "nirDark.fits")
+        data = np.full((NREADS, 2, 2), LEVEL, dtype="f4")
+        ImageCube.fromCube(data, dict(GAIN=GAIN)).writeFits(self.path)
+        # The helpers under test touch no task state, so skip __init__.
+        self.task = PfsIsrTask.__new__(PfsIsrTask)
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def testGetDarkReadBacksOutGain(self):
+        dark = ImageCube.readFits(self.path)
+        self.assertFloatsAlmostEqual(self.task.getDarkRead(dark, 0), LEVEL / GAIN)
+
+    def testGetDarkReadDoesNotCorruptTheCube(self):
+        """Reading the same read twice must give the same answer."""
+        dark = ImageCube.readFits(self.path)
+        first = self.task.getDarkRead(dark, 0).copy()
+        second = self.task.getDarkRead(dark, 0)
+        self.assertFloatsAlmostEqual(second, first)
+        # ...and the cached image is still in electrons, unscaled.
+        self.assertFloatsAlmostEqual(dark[0].array, LEVEL)
+
+    def testGetDarkReadReturnsNewArray(self):
+        """The caller must not be handed the cube's cached image."""
+        dark = ImageCube.readFits(self.path)
+        read = self.task.getDarkRead(dark, 0)
+        read += 1000.0
+        self.assertFloatsAlmostEqual(dark[0].array, LEVEL)
+
+    def testGetDarkReadWithoutGain(self):
+        path = os.path.join(self.root, "noGain.fits")
+        ImageCube.fromCube(np.full((NREADS, 2, 2), LEVEL, dtype="f4"), {}).writeFits(path)
+        dark = ImageCube.readFits(path)
+        read = self.task.getDarkRead(dark, 0)
+        self.assertFloatsAlmostEqual(read, LEVEL)
+        read += 1000.0  # still a copy, even when the gain is 1
+        self.assertFloatsAlmostEqual(dark[0].array, LEVEL)
+
+    def testGetDarkReadPreservesDtype(self):
+        dark = ImageCube.readFits(self.path)
+        self.assertEqual(self.task.getDarkRead(dark, 0).dtype, np.float32)
+
+    def testGetDarkCubeBacksOutGainAndIsRepeatable(self):
+        dark = ImageCube.readFits(self.path)
+        self.assertFloatsAlmostEqual(self.task.getDarkCube(dark, NREADS), LEVEL / GAIN)
+        self.assertFloatsAlmostEqual(self.task.getDarkCube(dark, NREADS), LEVEL / GAIN)
+
+    def testGetDarkCubeTakesLeadingReads(self):
+        """A shorter exposure uses the leading planes of the dark."""
+        dark = ImageCube.readFits(self.path)
+        self.assertEqual(self.task.getDarkCube(dark, NREADS - 1).shape[0], NREADS - 1)
+
+    def testGetDarkCubeTooShortRaises(self):
+        """An exposure with more reads than the dark must not pass silently."""
+        dark = ImageCube.readFits(self.path)
+        with self.assertRaises(KeyError):
+            self.task.getDarkCube(dark, NREADS + 1)
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    setup_module(sys.modules["__main__"])
+    unittest.main(failfast=True)

--- a/tests/test_makeNirRawCubes.py
+++ b/tests/test_makeNirRawCubes.py
@@ -1,0 +1,240 @@
+"""Tests for the ``makeNirRawCubes`` command-line wrapper.
+
+The wrapper assembles a ``pipetask run`` command that produces the ``rawISRCube``
+ramps ``combineNirDark`` consumes. The tests check the assembled command line, the
+data-id expression, and -- most importantly -- that every config override names a
+field that really exists on `PfsIsrTask.ConfigClass`, since ``pipetask`` would
+otherwise reject them only at run time, hours into a submission.
+"""
+
+import sys
+import unittest
+
+import lsst.utils.tests
+
+from testUtils import HAS_DRP_STELLA, loadScript, requireDrpStella
+
+if HAS_DRP_STELLA:
+    # isrTask imports pfs.drp.stella.crosstalk, and the pipeline this script runs
+    # lives in drp_stella, so pipelinePath() needs the product set up too.
+    from lsst.obs.pfs.isrTask import PfsIsrTask
+
+
+@requireDrpStella
+class BuildCommandTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        self.script = loadScript("makeNirRawCubes")
+
+    def testVisitQueryPassesRangesThrough(self):
+        # The butler understands BEGIN..END itself, so no expansion is needed.
+        self.assertEqual(self.script.visitQuery(["144587..144636"]),
+                         "visit in (144587..144636) and arm='n'")
+        self.assertEqual(self.script.visitQuery(["1", "3..5"]),
+                         "visit in (1, 3..5) and arm='n'")
+
+    def testVisitQuerySpectrographs(self):
+        self.assertEqual(
+            self.script.visitQuery(["7"], [1, 3]),
+            "visit in (7) and arm='n' and spectrograph in (1, 3)")
+
+    def testCommandLine(self):
+        command = self.script.buildCommand(
+            "/work/datastore", ["u/me/badRefPixels", "PFS/defaults"], "u/me/out",
+            ["144587..144636"], processes=12)
+        self.assertEqual(command[0], "pipetask")
+        self.assertIn("run", command)
+        self.assertIn("--fail-fast", command)
+        for flag, value in (("-b", "/work/datastore"),
+                            ("-o", "u/me/out"),
+                            ("-i", "u/me/badRefPixels,PFS/defaults"),
+                            ("-j", "12"),
+                            ("-d", "visit in (144587..144636) and arm='n'")):
+            self.assertEqual(command[command.index(flag) + 1], value)
+        self.assertTrue(command[command.index("-p") + 1].endswith(
+            "/pipelines/reduceExposure.yaml#isr"))
+
+    def overrides(self, command):
+        return [command[i + 1] for i, a in enumerate(command) if a == "-c"]
+
+    def testRawCubeConfigApplied(self):
+        command = self.script.buildCommand("/repo", ["in"], "out", ["7"])
+        # Fixed corrections, then the default IRP config (use IRP, no smoothing).
+        self.assertEqual(self.overrides(command),
+                         list(self.script.ISR_CONFIG)
+                         + ["isr:h4.useIRP=True", "isr:h4.IRPfilter=0"])
+
+    def testIrpFilterSelectable(self):
+        command = self.script.buildCommand("/repo", ["in"], "out", ["7"], irpFilter=15)
+        self.assertIn("isr:h4.IRPfilter=15", self.overrides(command))
+        self.assertNotIn("isr:h4.IRPfilter=0", self.overrides(command))
+
+    def testPerColumnMedianMode(self):
+        command = self.script.buildCommand("/repo", ["in"], "out", ["7"], irpFilter=-1)
+        self.assertIn("isr:h4.IRPfilter=-1", self.overrides(command))
+
+    def testNoIrpBypassesReferencePlanes(self):
+        command = self.script.buildCommand("/repo", ["in"], "out", ["7"], useIRP=False)
+        overrides = self.overrides(command)
+        self.assertIn("isr:h4.useIRP=False", overrides)
+        # With IRP bypassed, no IRPfilter is emitted -- it does nothing.
+        self.assertFalse([o for o in overrides if o.startswith("isr:h4.IRPfilter")])
+
+    def testExtraConfigAppliedLast(self):
+        command = self.script.buildCommand("/repo", ["in"], "out", ["7"],
+                                           config=["isr:h4.doCR=True"])
+        self.assertEqual(self.overrides(command)[-1], "isr:h4.doCR=True")
+
+    def testLogLevelOmittedByDefault(self):
+        self.assertNotIn("--log-level", self.script.buildCommand("/repo", ["in"], "out", ["7"]))
+        command = self.script.buildCommand("/repo", ["in"], "out", ["7"], logLevel=".=DEBUG")
+        self.assertEqual(command[command.index("--log-level") + 1], ".=DEBUG")
+
+    def testShowPassedThrough(self):
+        self.assertNotIn("--show", self.script.buildCommand("/repo", ["in"], "out", ["7"]))
+        command = self.script.buildCommand("/repo", ["in"], "out", ["7"], show=["config", "uri"])
+        shown = [command[i + 1] for i, a in enumerate(command) if a == "--show"]
+        self.assertEqual(shown, ["config", "uri"])
+
+    def testScratchCollectionLayout(self):
+        self.assertEqual(self.script.scratchCollection("u/cpl/calib", "PIPE2D-1664", "irp4"),
+                         "u/cpl/calib/PIPE2D-1664/irp4/scratchCubes")
+
+
+@requireDrpStella
+class MainTestCase(lsst.utils.tests.TestCase):
+    """``main`` marshals its arguments the way combineNirDark does."""
+
+    def setUp(self):
+        self.script = loadScript("makeNirRawCubes")
+        self.origArgv = sys.argv
+
+    def tearDown(self):
+        sys.argv = self.origArgv
+
+    def run_main(self, argv):
+        sys.argv = ["makeNirRawCubes"] + argv
+        self.script.main()
+
+    def capture(self, argv):
+        """Run main() in --dry-run and return the printed command as a list."""
+        import io
+        import contextlib
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.run_main(argv + ["--dry-run"])
+        import shlex
+        return shlex.split(out.getvalue().strip())
+
+    def testDefaultOutputIsScratchCubes(self):
+        command = self.capture(["/repo", "--input", "in", "--output", "u/me/calib",
+                                "--ticket", "PIPE2D-1664", "--tag", "irp4",
+                                "--visits", "7"])
+        self.assertEqual(command[command.index("-o") + 1],
+                         "u/me/calib/PIPE2D-1664/irp4/scratchCubes")
+
+    def testOutputCollectionOverride(self):
+        command = self.capture(["/repo", "--input", "in", "--output", "u/me/calib",
+                                "--ticket", "T", "--tag", "g", "--visits", "7",
+                                "--output-collection", "u/me/explicit"])
+        self.assertEqual(command[command.index("-o") + 1], "u/me/explicit")
+
+    def testDefaultsAppendedToInputs(self):
+        command = self.capture(["/repo", "--input", "in", "--output", "u/me/calib",
+                                "--ticket", "T", "--tag", "g", "--visits", "7"])
+        self.assertEqual(command[command.index("-i") + 1], "in,PFS/defaults")
+
+    def testDefaultsNotDuplicated(self):
+        command = self.capture(["/repo", "--input", "in", "PFS/defaults",
+                                "--output", "u/me/calib", "--ticket", "T", "--tag", "g",
+                                "--visits", "7"])
+        self.assertEqual(command[command.index("-i") + 1], "in,PFS/defaults")
+
+    def testSpectrographRestriction(self):
+        command = self.capture(["/repo", "--input", "in", "--output", "u/me/calib",
+                                "--ticket", "T", "--tag", "g", "--visits", "7",
+                                "--spectrograph", "1", "2"])
+        self.assertEqual(command[command.index("-d") + 1],
+                         "visit in (7) and arm='n' and spectrograph in (1, 2)")
+
+    def testTicketAndTagRequired(self):
+        for missing in (["--ticket", "T"], ["--tag", "g"]):
+            with self.assertRaises(SystemExit):
+                self.run_main(["/repo", "--input", "in", "--output", "u/me/calib",
+                               "--visits", "7", *missing, "--dry-run"])
+
+    def testIrpFlagsReachCommand(self):
+        command = self.capture(["/repo", "--input", "in", "--output", "u/me/calib",
+                                "--ticket", "T", "--tag", "g", "--visits", "7",
+                                "--irp-filter", "-1"])
+        overrides = [command[i + 1] for i, a in enumerate(command) if a == "-c"]
+        self.assertIn("isr:h4.IRPfilter=-1", overrides)
+
+    def testNoIrpFlagReachesCommand(self):
+        command = self.capture(["/repo", "--input", "in", "--output", "u/me/calib",
+                                "--ticket", "T", "--tag", "g", "--visits", "7", "--no-irp"])
+        overrides = [command[i + 1] for i, a in enumerate(command) if a == "-c"]
+        self.assertIn("isr:h4.useIRP=False", overrides)
+        self.assertFalse([o for o in overrides if o.startswith("isr:h4.IRPfilter")])
+
+
+@requireDrpStella
+class IsrConfigFieldsTestCase(lsst.utils.tests.TestCase):
+    """Every override must name a real config field, and actually change it."""
+
+    def setUp(self):
+        self.script = loadScript("makeNirRawCubes")
+        self.config = PfsIsrTask.ConfigClass()
+
+    def assertFieldExists(self, override):
+        label, _, assignment = override.partition(":")
+        self.assertEqual(label, "isr")
+        name, _, _value = assignment.partition("=")
+        target = self.config
+        *parents, leaf = name.split(".")
+        for parent in parents:
+            target = getattr(target, parent)
+        self.assertTrue(hasattr(target, leaf), f"{name} is not a PfsIsrTask config field")
+
+    def testOverriddenFieldsExist(self):
+        # Every override -- fixed, and both IRP branches -- must name a real field,
+        # or pipetask would reject it only at run time, hours into a submission.
+        allOverrides = (self.script.ISR_CONFIG
+                        + self.script.irpConfig(0, True)
+                        + self.script.irpConfig(-1, True)
+                        + self.script.irpConfig(0, False))
+        for override in allOverrides:
+            self.assertFieldExists(override)
+
+    def testRawCubesRequireUncorrectedRamps(self):
+        """The darks must be combined without linearity or a dark subtracted."""
+        overrides = dict(
+            override.split(":", 1)[1].split("=", 1) for override in self.script.ISR_CONFIG)
+        self.assertEqual(overrides["doDark"], "False")
+        self.assertEqual(overrides["h4.doLinearize"], "False")
+        self.assertEqual(overrides["h4.doWriteRawCube"], "True")
+
+    def testDefaultIrpFilterNoSmoothing(self):
+        overrides = dict(o.split(":", 1)[1].split("=", 1)
+                         for o in self.script.irpConfig(self.script.DEFAULT_IRP_FILTER, True))
+        self.assertEqual(overrides["h4.useIRP"], "True")
+        self.assertEqual(overrides["h4.IRPfilter"], "0")
+
+    def testOverridesDifferFromDefaults(self):
+        """A no-op override would mean the default drifted under us."""
+        self.assertTrue(self.config.doDark)
+        self.assertTrue(self.config.h4.doLinearize)
+        self.assertFalse(self.config.h4.doWriteRawCube)
+        self.assertNotEqual(self.config.h4.IRPfilter, self.script.DEFAULT_IRP_FILTER)
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    setup_module(sys.modules["__main__"])
+    unittest.main(failfast=True)

--- a/tests/test_nirSuperdark.py
+++ b/tests/test_nirSuperdark.py
@@ -1,0 +1,368 @@
+"""Tests for the combined-NIR-dark core (``lsst.obs.pfs.nirSuperdark``).
+
+Exercises the read-by-read median combine (``makeMasterDark``), its input-
+consistency guards, and the butler round-trip of ``saveNirDark`` including the
+IRP-ratio-driven dataset-type selection (``nirDark`` vs ``nirDark_irp4``) and the
+IRP/timing metadata cards.
+"""
+
+import datetime
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+import astropy.time
+import astropy.units as u
+import numpy as np
+
+import lsst.resources
+import lsst.utils.tests
+from lsst.daf.butler import CollectionType, Timespan
+
+from lsst.obs.pfs.imageCube import ImageCube
+
+from testUtils import HAS_DRP_STELLA, loadScript, requireDrpStella
+
+if HAS_DRP_STELLA:
+    # nirSuperdark imports pfs.drp.stella.calibs.setCalibHeader.
+    from lsst.obs.pfs import nirSuperdark
+
+
+class FakeButler:
+    """Minimal butler stand-in for ``makeMasterDark``.
+
+    ``makeMasterDark`` only calls ``getURI('rawISRCube', dataId, visit=...)`` and
+    opens the result with ``fitsio``; a ``ResourcePath`` to an on-disk cube (what
+    the real butler returns) is all that is needed.
+    """
+
+    def __init__(self, paths):
+        self.paths = paths  # visit -> file path
+
+    def getURI(self, datasetType, dataId, visit):
+        assert datasetType == "rawISRCube"
+        return lsst.resources.ResourcePath(self.paths[visit])
+
+
+def writeCube(path, data, irpN=1, irpOffset=1, frameTime=1.5, nred=None):
+    """Write a synthetic rawISRCube FITS file with H4 header cards.
+
+    A rawISRCube has one plane fewer than the ramp has reads, so ``W_H4NRED`` is
+    one more than ``len(data)`` unless overridden to test the guard.
+    """
+    if nred is None:
+        nred = len(data) + 1
+    metadata = dict(W_H4IRPN=irpN, W_H4IRPO=irpOffset,
+                    W_H4NRED=nred, W_H4FRMT=frameTime)
+    ImageCube.fromCube(data, metadata).writeFits(path)
+
+
+@requireDrpStella
+class MakeMasterDarkTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="nirSuperdark-")
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def makeInputs(self, offsetsPerDark, nreads=3, shape=(4, 5), irpN=1):
+        """Write darks that share a common ramp plus a constant per-dark offset.
+
+        Dark ``v`` at every read is ``base[r] + offsetsPerDark[v]``, where
+        ``base[r]`` is a flat image of value ``10*(r+1)`` (the common flux ramp).
+        """
+        butler = FakeButler({})
+        for v, off in enumerate(offsetsPerDark):
+            data = np.empty((nreads,) + shape, dtype="f4")
+            for r in range(nreads):
+                data[r] = 10 * (r + 1) + off
+            path = os.path.join(self.root, f"cube_{v}.fits")
+            writeCube(path, data, irpN=irpN)
+            butler.paths[v] = path
+        return butler, list(range(len(offsetsPerDark)))
+
+    def testCombinePreservesCommonRamp(self):
+        """The common flux ramp survives; only inter-dark offsets are removed."""
+        offsets = [0.0, 10.0, 20.0]  # median 10 -> preserved in the result
+        butler, visits = self.makeInputs(offsets, nreads=3, shape=(4, 5))
+        newCube, perReadOffsets, rampInfo = nirSuperdark.makeMasterDark(
+            butler, dict(instrument="PFS", arm="n", spectrograph=1), visits)
+
+        self.assertEqual(newCube.shape, (3, 4, 5))
+        for r in range(3):
+            # result == base + median(offsets) == 10*(r+1) + 10
+            self.assertFloatsAlmostEqual(newCube[r], 10 * (r + 1) + 10.0)
+            # offsets recorded relative to the per-read median
+            np.testing.assert_allclose(perReadOffsets[r], [-10.0, 0.0, 10.0])
+
+        self.assertEqual(rampInfo["W_H4IRPN"], 1)
+        # One more read than there are planes: the first read is the reference.
+        self.assertEqual(rampInfo["W_H4NRED"], 4)
+        self.assertEqual(rampInfo["W_H4FRMT"], 1.5)
+
+    def testIdenticalDarksCombineToInput(self):
+        butler, visits = self.makeInputs([0.0, 0.0], nreads=4, shape=(3, 3))
+        newCube, offsets, _ = nirSuperdark.makeMasterDark(
+            butler, dict(instrument="PFS", arm="n", spectrograph=1), visits)
+        for r in range(4):
+            self.assertFloatsAlmostEqual(newCube[r], 10 * (r + 1))
+            np.testing.assert_allclose(offsets[r], [0.0, 0.0])
+
+    def testMismatchedReadCountRaises(self):
+        butler = FakeButler({})
+        for v, nreads in ((0, 3), (1, 2)):
+            data = np.ones((nreads, 3, 3), dtype="f4")
+            path = os.path.join(self.root, f"cube_{v}.fits")
+            writeCube(path, data)
+            butler.paths[v] = path
+        with self.assertRaises(ValueError):
+            nirSuperdark.makeMasterDark(
+                butler, dict(instrument="PFS", arm="n", spectrograph=1), [0, 1])
+
+    def testPlaneCountMustMatchReadCount(self):
+        """A rawISRCube must hold exactly W_H4NRED-1 planes."""
+        butler = FakeButler({})
+        data = np.ones((3, 3, 3), dtype="f4")
+        path = os.path.join(self.root, "cube_0.fits")
+        writeCube(path, data, nred=3)  # 3 planes claiming 3 reads; should be 4
+        butler.paths[0] = path
+        with self.assertRaises(ValueError) as cm:
+            nirSuperdark.makeMasterDark(
+                butler, dict(instrument="PFS", arm="n", spectrograph=1), [0])
+        self.assertIn("W_H4NRED", str(cm.exception))
+
+    def testMismatchedIrpRaises(self):
+        butler = FakeButler({})
+        for v, irpN in ((0, 1), (1, 4)):
+            data = np.ones((3, 3, 3), dtype="f4")
+            path = os.path.join(self.root, f"cube_{v}.fits")
+            writeCube(path, data, irpN=irpN)
+            butler.paths[v] = path
+        with self.assertRaises(ValueError):
+            nirSuperdark.makeMasterDark(
+                butler, dict(instrument="PFS", arm="n", spectrograph=1), [0, 1])
+
+
+@requireDrpStella
+class DatasetTypeForIrpTestCase(lsst.utils.tests.TestCase):
+    def testMapping(self):
+        self.assertEqual(nirSuperdark.datasetTypeForIrp(1), "nirDark")
+        self.assertEqual(nirSuperdark.datasetTypeForIrp(4), "nirDark_irp4")
+        self.assertEqual(nirSuperdark.datasetTypeForIrp(2), "nirDark_irp2")
+
+
+@requireDrpStella
+class SaveNirDarkTestCase(lsst.utils.tests.TestCase):
+    """Round-trip ``saveNirDark`` through a throwaway Gen3 butler."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.root = tempfile.mkdtemp(prefix="nirSuperdark-repo-")
+        repo = os.path.join(cls.root, "repo")
+        cls.butler = loadScript("makePfsTestRepo").makePfsTestRepo(repo)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.root, ignore_errors=True)
+
+    START = datetime.datetime(2026, 7, 8, 12, 0, 0)
+
+    def roundTrip(self, irpN, expectedType, saveDir=None, runColl=None,
+                  calibCollection=None):
+        # A dedicated run per case so the presence check below is unambiguous,
+        # and so no two cases put the same dataset into the same run.
+        if runColl is None:
+            runColl = f"u/test/PIPE2D-1664/{expectedType}"
+        self.butler.registry.registerRun(runColl)
+        self.runColl = runColl
+        if calibCollection is not None:
+            nirSuperdark.ensureCalibCollection(self.butler, calibCollection)
+        dataId = dict(instrument="PFS", arm="n", spectrograph=1)
+        data = np.arange(3 * 4 * 5, dtype="f4").reshape(3, 4, 5)
+        rampInfo = dict(W_H4IRPN=irpN, W_H4IRPO=1, W_H4NRED=3, W_H4FRMT=1.5)
+        nirSuperdark.saveNirDark(
+            self.butler, dataId, runColl, [11, 22, 33], data,
+            start=self.START,
+            readNoise=5.0, gain=2.5, rampInfo=rampInfo, saveDir=saveDir,
+            calibCollection=calibCollection)
+        cube = self.butler.get(expectedType, dataId, collections=runColl)
+        self.assertEqual(cube.nreads, 3)
+        self.assertFloatsAlmostEqual(cube.getImageCube(), data)
+        # IRP/timing cards recorded for cadence matching
+        self.assertEqual(cube.metadata.get("W_H4IRPN"), irpN)
+        self.assertEqual(cube.metadata.get("W_H4IRPO"), 1)  # 1..W_H4IRPN, never 0
+        self.assertEqual(cube.metadata.get("W_H4FRMT"), 1.5)
+        self.assertEqual(cube.metadata.get("W_H4NRED"), 3)
+        # calib bookkeeping and dark descriptors
+        self.assertEqual(cube.metadata.get("OBSTYPE"), "dark")
+        self.assertEqual(cube.metadata.get("GAIN"), 2.5)
+        return dataId
+
+    def testNirDarkDefaultType(self):
+        self.roundTrip(1, "nirDark")
+
+    def testNirDarkIrp4Type(self):
+        dataId = self.roundTrip(4, "nirDark_irp4")
+        # An IRP4 combine must not masquerade as the default nirDark.
+        self.assertIsNone(
+            self.butler.registry.findDataset("nirDark", dataId, collections=self.runColl))
+
+    def testSavedOutsideButlerBeforePut(self):
+        """The cube is written to disk so a butler failure cannot discard it."""
+        saveDir = tempfile.mkdtemp(prefix="nirSuperdark-save-", dir=self.root)
+        self.roundTrip(1, "nirDark", saveDir=saveDir,
+                       runColl="u/test/PIPE2D-1664/nirDark-saved")
+        path = os.path.join(saveDir, "nirDark-n1.fits")
+        self.assertTrue(os.path.exists(path))
+        onDisk = ImageCube.readFits(path)
+        self.assertEqual(onDisk.nreads, 3)
+        self.assertEqual(onDisk.metadata.get("W_H4IRPN"), 1)
+
+    def testCertifiedIntoCalibCollection(self):
+        """The dark is certified so ISR can select it by observation date."""
+        calib = "u/test/PIPE2D-1664/certified/nirDarkGen.20260709a"
+        dataId = self.roundTrip(1, "nirDark", runColl=f"{calib}/put",
+                                calibCollection=calib)
+        registry = self.butler.registry
+        # Valid at and after the start date...
+        after = astropy.time.Time(self.START, format="datetime", scale="utc") + 1 * u.day
+        self.assertIsNotNone(
+            registry.findDataset("nirDark", dataId, collections=calib,
+                                 timespan=Timespan(after, after)))
+        # ...and open-ended, so a far-future exposure still finds it.
+        far = astropy.time.Time("2099-01-01T00:00:00", format="isot", scale="utc")
+        self.assertIsNotNone(
+            registry.findDataset("nirDark", dataId, collections=calib,
+                                 timespan=Timespan(far, far)))
+        # Not valid before it was taken.
+        before = astropy.time.Time("2020-01-01T00:00:00", format="isot", scale="utc")
+        self.assertIsNone(
+            registry.findDataset("nirDark", dataId, collections=calib,
+                                 timespan=Timespan(before, before)))
+
+
+@requireDrpStella
+class CollectionNameTestCase(lsst.utils.tests.TestCase):
+    def testCalibCollectionDropsGenSuffix(self):
+        """Matches the pipeline calibs, e.g. PFS/calib/.../dark.20260503a."""
+        self.assertEqual(
+            nirSuperdark.calibCollectionName("u/me/calib", "PIPE2D-1664", "run30",
+                                             "nirDark_irp4", "20260709a"),
+            "u/me/calib/PIPE2D-1664/run30/nirDark_irp4.20260709a")
+
+    def testGenCollectionAndTimestampedRun(self):
+        gen = nirSuperdark.genCollectionName("u/me/calib", "PIPE2D-1664", "run30",
+                                             "nirDark_irp4", "20260709a")
+        self.assertEqual(gen, "u/me/calib/PIPE2D-1664/run30/nirDark_irp4Gen.20260709a")
+        self.assertEqual(nirSuperdark.runName(gen, "20260709T123456Z"),
+                         f"{gen}/20260709T123456Z")
+
+    def testGenAndCalibDifferOnlyBySuffix(self):
+        args = ("u/me/calib", "PIPE2D-1664", "run30", "nirDark", "20260709a")
+        self.assertNotEqual(nirSuperdark.calibCollectionName(*args),
+                            nirSuperdark.genCollectionName(*args))
+
+    def testTrailingSlashOnBaseStripped(self):
+        """A trailing slash must not become a // in the collection name."""
+        args = ("PIPE2D-1664", "irp4", "nirDark_irp4", "20260709a")
+        self.assertEqual(nirSuperdark.calibCollectionName("u/cpl/calib/", *args),
+                         nirSuperdark.calibCollectionName("u/cpl/calib", *args))
+        self.assertEqual(nirSuperdark.genCollectionName("u/cpl/calib///", *args),
+                         nirSuperdark.genCollectionName("u/cpl/calib", *args))
+        self.assertNotIn("//", nirSuperdark.calibCollectionName("u/cpl/calib/", *args))
+
+    def testEmptyBaseRejected(self):
+        for bad in ("", "/", "///"):
+            with self.assertRaises(ValueError):
+                nirSuperdark.collectionRoot(bad)
+
+    def testDefaultIteration(self):
+        self.assertRegex(nirSuperdark.defaultIteration(), r"^\d{8}a$")
+
+    def testDefaultTimestampIsUtc(self):
+        self.assertRegex(nirSuperdark.defaultTimestamp(), r"^\d{8}T\d{6}Z$")
+
+
+@requireDrpStella
+class EnsureOutputsTestCase(lsst.utils.tests.TestCase):
+    """``ensureOutputs`` must catch, up front, what would fail the final put."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.root = tempfile.mkdtemp(prefix="nirSuperdark-outputs-")
+        repo = os.path.join(cls.root, "repo")
+        cls.butler = loadScript("makePfsTestRepo").makePfsTestRepo(repo)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.root, ignore_errors=True)
+
+    def testCollectionsCreated(self):
+        calib = "u/test/PIPE2D-1664/fresh/nirDark.20260709a"
+        gen = "u/test/PIPE2D-1664/fresh/nirDarkGen.20260709a"
+        runColl = nirSuperdark.runName(gen, "20260709T010101Z")
+        nirSuperdark.ensureOutputs(self.butler, runColl, calib, "nirDark")
+        registry = self.butler.registry
+        self.assertEqual(registry.getCollectionType(runColl), CollectionType.RUN)
+        self.assertEqual(registry.getCollectionType(calib), CollectionType.CALIBRATION)
+
+    def testChainedCollectionRaises(self):
+        chain = "u/test/PIPE2D-1664/chain"
+        self.butler.registry.registerCollection(chain, CollectionType.CHAINED)
+        with self.assertRaises(ValueError) as cm:
+            nirSuperdark.ensureRunCollection(self.butler, chain)
+        self.assertIn("CHAINED", str(cm.exception))
+
+    def testGenCollectionChainsRunFirst(self):
+        gen = "u/test/PIPE2D-1664/gen/nirDarkGen.20260709a"
+        run = f"{gen}/20260709T010101Z"
+        for name in (run, "u/test/PIPE2D-1664/inputs"):
+            self.butler.registry.registerRun(name)
+        nirSuperdark.ensureGenCollection(self.butler, gen, [run, "u/test/PIPE2D-1664/inputs"])
+        registry = self.butler.registry
+        self.assertEqual(registry.getCollectionType(gen), CollectionType.CHAINED)
+        self.assertEqual(list(registry.getCollectionChain(gen)),
+                         [run, "u/test/PIPE2D-1664/inputs"])
+
+    def testRerunPrependsNewRunAndKeepsOld(self):
+        """A second attempt must not drop the previous run from the chain."""
+        gen = "u/test/PIPE2D-1664/rerun/nirDarkGen.20260709a"
+        first, second = f"{gen}/20260709T010101Z", f"{gen}/20260709T020202Z"
+        for name in (first, second):
+            self.butler.registry.registerRun(name)
+        nirSuperdark.ensureGenCollection(self.butler, gen, [first])
+        nirSuperdark.ensureGenCollection(self.butler, gen, [second])
+        self.assertEqual(list(self.butler.registry.getCollectionChain(gen)),
+                         [second, first])
+        # Idempotent: repeating the second call changes nothing.
+        nirSuperdark.ensureGenCollection(self.butler, gen, [second])
+        self.assertEqual(list(self.butler.registry.getCollectionChain(gen)),
+                         [second, first])
+
+    def testUnknownDatasetTypeRegistered(self):
+        """A newly-introduced nirDark_irp<N> need not pre-exist in the repo."""
+        registry = self.butler.registry
+        datasetType = "nirDark_irp8"
+        with self.assertRaises(KeyError):
+            registry.getDatasetType(datasetType)
+        nirSuperdark.ensureDatasetType(self.butler, datasetType)
+        registered = registry.getDatasetType(datasetType)
+        self.assertEqual(registered.storageClass_name, "ImageCube")
+        self.assertTrue(registered.isCalibration())
+        # Idempotent: a second call on an existing repo must not raise.
+        nirSuperdark.ensureDatasetType(self.butler, datasetType)
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    setup_module(sys.modules["__main__"])
+    unittest.main(failfast=True)

--- a/ups/obs_pfs.table
+++ b/ups/obs_pfs.table
@@ -1,5 +1,6 @@
 setupRequired(afw)
 setupRequired(daf_base)
+setupRequired(datamodel)
 setupRequired(obs_base)
 setupRequired(ip_isr)
 setupRequired(pex_config)


### PR DESCRIPTION
[PIPE2D-1664](https://pfspipe.ipmu.jp/jira/browse/PIPE2D-1664)

Combine multiple raw NIR dark ramps into a single master `nirDark` that ISR
subtracts from an exposure read-by-read.

## What this adds

- **`nirSuperdark.py`** — combine a set of `rawISRCube` ramps into a `nirDark`,
  certify it, and lay out the output collections per
  [DMTN-222](https://dmtn-222.lsst.io) (`{root}/{ticket}/{tag}/{product}.{iteration}`
  CALIBRATION, a `Gen` generation chain, and a timestamped RUN).
- **Command-line tools:**
  - `makeNirRawCubes.py` — generate the raw input cubes (`pipetask` wrapper;
    selectable IRP handling via `--irp-filter` / `--no-irp`).
  - `combineNirDark.py` — combine the cubes into a certified `nirDark`, with a
    preflight that resolves collections and validates inputs before the
    hours-long combine.
  - `copyDatasets.py` (+ `datasetCopy.py`) — copy/promote datasets between
    collections via artifact ingest.
- **`nirDark_irp4`** dataset type registration, for darks built from IRP-ratio-4
  ramps (co-defined with PIPE2D-1855).
- **`isrTask.py`** — `getDarkRead` returns a fresh, gain-corrected array so
  repeated reads of the cached cube are not corrupted.
- **`datamodel`** EUPS dependency, declared for the `pfs.datamodel` import that
  `imageCube` (used by every `ImageCube` product) relies on.
- Test suite covering the combine logic, all three CLIs, and the dark-cube ISR
  path.

The branch is rebased on current `master`; the `ip_isr` dependency and the
`drp_pfs_data` test skip are already provided by PIPE2D-1864 and are not
duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
